### PR TITLE
repartition: auto-create swap partition when disk space is plentiful

### DIFF
--- a/dracut/repartition/endless-repartition.sh
+++ b/dracut/repartition/endless-repartition.sh
@@ -1,14 +1,28 @@
 #!/bin/sh
 # The purpose of this script is to identify if we are running on target
-# Endless hardware and if so, modify the partition table so that the root
-# partition fills the disk.
+# Endless hardware and if so, enlarges partition 2 (data partition) to use
+# all available space.
+# When disk space is plentiful, we also carve out some space at the end of
+# the disk, and use it to create a swap partition (partition 3).
 #
-# It is important to identify an Endless device in a quick/cheap way.
-# We have such a mechanism in place just in case we might want to install
-# Endless on another setup at some point (e.g. for demo purposes).
-# To identify this, we check that the data partition is at partition 2,
-# there are no further partitions on the disk, and the type code for unused
-# partition entry 4 has magic number 'dd'.
+# It is important to identify that this system is an Endless-flashed device
+# that desires such treatment. We do this by detecting that the type code for
+# unused partition entry 4 has magic number 'dd', which is deliberately set in
+# EOS images. If you need to avoid such repartitioning, just remove that 4th
+# partition before first boot.
+#
+# The dd "marker" is also removed after this script is run, providing a
+# quick/cheap way of knowing that our work is done, avoiding going through
+# all this logic on each boot.
+#
+# This script is written carefully so that it can be interrupted after each
+# operation, on next boot it should effectively continue where it left off.
+#
+# Special attention is given to the fact that modifying the partition table
+# causes the kernel to re-read the partition table, which causes udev to
+# quickly remove and recreate device nodes for affected disks. We call
+# "udevadm settle" after each partition table change to make sure that udev
+# has caught up with these events.
 #
 # Based on code from dracut-modules-olpc.
 
@@ -22,35 +36,25 @@ fi
 # Identify root partition device node and parent disk
 root_part=$(readlink -f ${root#block:})
 if [ -z ${root_part} ]; then
-  echo "resize: no root found"
+  echo "repartition: no root found"
   exit 0
 fi
 
 case ${root_part} in
-  /dev/mmcblk?p2) root_disk=${root_part%p2} ;;
-  /dev/sd?2) root_disk=${root_part%2} ;;
+  /dev/mmcblk?p2)
+    root_disk=${root_part%p2}
+    swap_part=${root_part%?}3
+    ;;
+  /dev/sd?2)
+    root_disk=${root_part%2}
+    swap_part=${root_part%?}3
+    ;;
 esac
 
 if [ -z "${root_disk}" ]; then
-  echo "resize: no root disk found for $root_part"
+  echo "repartition: no root disk found for $root_part"
   exit 0
 fi
-
-# Check that our partition is the final partition
-if [ -e "${root_disk}3" -o -e "${root_disk}4" -o -e "${root_disk}p3" -o -e "${root_disk}p4" ]; then
-  echo "resize: extra partitions found, not resizing"
-  exit 0
-fi
-
-# Check that our partition doesn't already fill the disk
-root_disk_name=${root_disk#/dev/}
-root_part_name=${root_part#/dev/}
-disk_size=$(cat /sys/class/block/$root_disk_name/size)
-part_size=$(cat /sys/class/block/$root_part_name/size)
-part_start=$(cat /sys/class/block/$root_part_name/start)
-part_end=$(( part_start + part_size ))
-echo "Dsize $disk_size Psize $part_size Pstart $part_start Pend $part_end"
-[ "$part_end" = "$disk_size" ] && exit 0
 
 # We should also check that we are working with a MBR partition table, to
 # avoid destroying any non-Endless GPT setup.
@@ -63,21 +67,55 @@ echo "Dsize $disk_size Psize $part_size Pstart $part_start Pend $part_end"
 # Check for our magic "this is Endless" marker
 marker=$(sfdisk --force --print-id $root_disk 4)
 if [ "$marker" != "dd" ]; then
-  echo "resize: marker not found"
+  echo "repartition: marker not found"
   exit 0
 fi
 
-# udev might still be busy probing the disk, meaning that it will be in
-# use. Give it a chance to finish first.
-udevadm settle
+root_disk_name=${root_disk#/dev/}
+root_part_name=${root_part#/dev/}
+disk_size=$(cat /sys/class/block/$root_disk_name/size)
+part_size=$(cat /sys/class/block/$root_part_name/size)
+part_start=$(cat /sys/class/block/$root_part_name/start)
+part_end=$(( part_start + part_size ))
+echo "Dsize $disk_size Psize $part_size Pstart $part_start Pend $part_end"
 
-echo "Try to resize $root_disk"
-echo ",+,," | sfdisk --force --no-reread -N2 -uS -S 32 -H 32 $root_disk
-echo "sfdisk returned $?"
+# If we find ourselves with >100GB free space, we'll use the final 4GB as
+# a swap partition
+new_size=$(( disk_size - part_start ))
+added_space=$(( new_size - part_size ))
+if [ $added_space -gt 209715200 ]; then
+  new_size=$(( new_size - 8388608 ))
+  swap_start=$(( part_start + new_size ))
 
-# Remove marker
+  # Align swap partition start to 1MB boundary
+  residue=$(( swap_start % 2048 ))
+  if [ $residue -gt 0 ]; then
+    swap_start=$(( swap_start + 2048 - residue ))
+    # might as well bump up root partition size too, instead of leaving a gap
+    new_size=$(( new_size + 2048 - residue ))
+  fi
+fi
+
+if [ $new_size -gt $part_size ]; then
+  # udev might still be busy probing the disk, meaning that it will be in use.
+  udevadm settle
+
+  echo "Try to resize $root_part to fill $new_size sectors"
+  echo ",$new_size,," | sfdisk --force --no-reread -N2 -uS -S 32 -H 32 $root_disk
+  echo "sfdisk returned $?"
+  udevadm settle
+fi
+
+if [ -n "$swap_start" ]; then
+  # Create swap partition
+  echo "Create swap partition at $swap_start"
+  echo "$swap_start,+,S," | sfdisk --force --no-reread -N3 -uS -S 32 -H 32 $root_disk
+  echo "sfdisk returned $?"
+  udevadm settle
+fi
+
+[ -e "$swap_part" ] && mkswap -L eos-swap $swap_part
+
+# Remove marker - must be done last, prevents this script from running again
 sfdisk --force --change-id $root_disk 4 0
-
-# Partition nodes are removed and recreated now - wait for udev to finish
-# recreating them before trying to mount the disk.
 udevadm settle

--- a/dracut/repartition/module-setup.sh
+++ b/dracut/repartition/module-setup.sh
@@ -10,5 +10,6 @@ install() {
   dracut_install sfdisk
   dracut_install basename
   dracut_install readlink
+  dracut_install mkswap
   inst_hook pre-mount 50 "$moddir/endless-repartition.sh"
 }


### PR DESCRIPTION
When we have a lot of disk space, create a swap partition at the
end of the disk.

Now that we have multiple steps to do, refactor the script a little,
so that it can be safely interrupted between each operation.

[endlessm/eos-shell#2458]
