### PR TITLE
Launch initramfs part as systemd service

### DIFF
--- a/dracut/repartition/endless-repartition.service
+++ b/dracut/repartition/endless-repartition.service
@@ -1,0 +1,16 @@
+[Unit]
+Description=EOS repartitioning
+
+# Dependencies based around dracut-pre-mount.service
+DefaultDependencies=no
+Before=initrd-root-fs.target sysroot.mount
+After=dracut-pre-mount.service
+ConditionPathExists=/etc/initrd-release
+
+# fsck might be using the disk - avoid running at the same time
+Before=systemd-fsck@dev-disk-by\x2dlabel-ostree.service
+
+[Service]
+Type=oneshot
+ExecStart=-/bin/endless-repartition
+RemainAfterExit=yes

--- a/dracut/repartition/module-setup.sh
+++ b/dracut/repartition/module-setup.sh
@@ -3,7 +3,7 @@ check() {
 }
 
 depends() {
-  echo fs-lib
+  echo fs-lib systemd
 }
 
 install() {
@@ -11,5 +11,10 @@ install() {
   dracut_install basename
   dracut_install readlink
   dracut_install mkswap
-  inst_hook pre-mount 50 "$moddir/endless-repartition.sh"
+  inst_script "$moddir/endless-repartition.sh" /bin/endless-repartition
+  inst_simple "$moddir/endless-repartition.service" \
+	"$systemdsystemunitdir/endless-repartition.service"
+  mkdir -p "${initdir}/$systemdsystemunitdir/initrd.target.wants"
+  ln_r "$systemdsystemunitdir/endless-repartition.service" \
+	"$systemdsystemunitdir/initrd.target.wants/endless-repartition.service"
 }


### PR DESCRIPTION
Now that we're fscking the root partition from the initramfs,
the fsck task is running at the same time as the repartition script.

To prevent this, we need a bit more control, so convert the repartition
script to a systemd service unit and make it finish execution before
fsck is run.

[endlessm/eos-shell#2819]
