### PR TITLE
initramfs diet

### DIFF
--- a/dracut/endless.conf
+++ b/dracut/endless.conf
@@ -1,0 +1,3 @@
+dracutmodules="dash drm eos-repartition plymouth kernel-modules resume ostree systemd base"
+fscks="fsck fsck.ext4"
+filesystems="ext4"

--- a/dracut/repartition/endless-repartition.service
+++ b/dracut/repartition/endless-repartition.service
@@ -7,7 +7,9 @@ Before=initrd-root-fs.target sysroot.mount
 After=dracut-pre-mount.service
 ConditionPathExists=/etc/initrd-release
 
-# fsck might be using the disk - avoid running at the same time
+# wait for the root device to be ready, but avoid running at the same time
+# as fsck.
+After=dev-disk-by\x2dlabel-ostree.device
 Before=systemd-fsck@dev-disk-by\x2dlabel-ostree.service
 
 [Service]

--- a/dracut/repartition/endless-repartition.sh
+++ b/dracut/repartition/endless-repartition.sh
@@ -29,12 +29,8 @@
 exec > /dev/kmsg
 exec 2>&1
 
-if [ -f /dracut-state.sh ]; then
-    . /dracut-state.sh 2>/dev/null
-fi
-
 # Identify root partition device node and parent disk
-root_part=$(readlink -f ${root#block:})
+root_part=$(readlink -f /dev/disk/by-label/ostree)
 if [ -z ${root_part} ]; then
   echo "repartition: no root found"
   exit 0

--- a/dracut/repartition/module-setup.sh
+++ b/dracut/repartition/module-setup.sh
@@ -3,12 +3,11 @@ check() {
 }
 
 depends() {
-  echo fs-lib systemd
+  echo systemd
 }
 
 install() {
   dracut_install sfdisk
-  dracut_install basename
   dracut_install readlink
   dracut_install mkswap
   inst_script "$moddir/endless-repartition.sh" /bin/endless-repartition


### PR DESCRIPTION
Add an endless dracut.conf.d entry that reduces the set of
modules included in the initramfs to the ones we use.

Similarly reduce the amount of fscks included, and fs drivers.

The initramfs drops from 22mb to 15mb as a result.

However, with fewer modules, dracut's cmdline and initqueue helpers
no longer run. This means that eos-repartition can be started before
the root device exists, and the root= shell parsing no longer happens.
Adjust eos-repartition dependencies to require the root device.

[endlessm/eos-shell#2390]
