### PR TITLE
Dracut config: add fs-lib module

### DIFF
--- a/dracut/endless.conf
+++ b/dracut/endless.conf
@@ -1,3 +1,3 @@
-dracutmodules="dash drm eos-repartition plymouth kernel-modules resume ostree systemd base"
+dracutmodules="dash drm eos-repartition plymouth kernel-modules resume ostree systemd base fs-lib"
 fscks="fsck fsck.ext4"
 filesystems="ext4"


### PR DESCRIPTION
This module is needed so that fscks get included in the initramfs,
enabling the automatic fsck of the root filesystem before it is
mounted in early boot.

[endlessm/eos-shell#4455]
