### PR TITLE
Handle failures in mounting /var/endless-extra

### DIFF
--- a/endless.mount
+++ b/endless.mount
@@ -4,7 +4,14 @@ After=local-fs-pre.target
 Conflicts=umount.target
 Before=umount.target
 Before=local-fs.target
-RequiresMountsFor=/var/endless /var/endless-extra
+
+# Overlay mount dependencies. It would be nice to use RequiresMountsFor
+# for both the directories, but we want to continue if the extra storage
+# mount at /var/endless-extra fails (SD card missing or has failed).
+# Manually add After and Wants for that unit.
+After=var-endless\x2dextra.mount
+Wants=var-endless\x2dextra.mount
+RequiresMountsFor=/var/endless
 
 [Mount]
 What=endless


### PR DESCRIPTION
Make /var/endless-extra mount a soft dependency of the /endless mount and reduce timeouts on the /var/endless-extra device. This covers the case that the SD card for /var/endless-extra has failed or is not inserted.

The second commit is not strictly needed and may not be wanted. It does keep the boot from blocking for 90 seconds if the SD card device never shows up.

This needs coordination with https://github.com/endlessm/eos-build/pull/27.

[endlessm/eos-shell#4470]
