### PR TITLE
firstboot: Fail on resize errors

### DIFF
--- a/eos-firstboot
+++ b/eos-firstboot
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/bash -e
 
 resize2fs "$(findmnt -rvnf -o SOURCE /)"
 


### PR DESCRIPTION
Enable the bash errexit option so that errors in resize2fs exit the
service with a failure. In addition to registering an error to systemd,
this prevents /var/eos-booted from being written, which would prevent
the service from being run again.

[endlessm/eos-shell#4535]
