### PR TITLE
repartition: open disk read-only when checking marker

### DIFF
--- a/dracut/repartition/endless-repartition.sh
+++ b/dracut/repartition/endless-repartition.sh
@@ -64,7 +64,7 @@ fi
 # bail out in such situations.
 
 # Check for our magic "this is Endless" marker
-marker=$(sfdisk --force --print-id $root_disk 4)
+marker=$(sfdisk -n --force --print-id $root_disk 4)
 if [ "$marker" != "dd" ]; then
   echo "repartition: marker not found"
   exit 0


### PR DESCRIPTION
In our current shipped version of util-linux, "sfdisk --print-id"
actually opens the disk as rw. When it later closes the device,
this causes the kernel to reprobe the partition table in case it
has changed, which can cause udev to recreate device nodes.

This is fixed in the new version of util-linux where this code
has been reworked into a new --part-type option.

Until we upgrade util-linux, add a workaround here: explicitly
asking sfdisk not to write to disk causes it to open the disk
as read-only here.

[endlessm/eos-shell#4771]