### PR TITLE
Add dynamically activated systemd swap unit

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -11,10 +11,14 @@ dist_systemdunit_DATA = \
 
 # Unfortunately, dist chokes on the escaped \x2d, so we need to
 # split this out into EXTRA_DIST unescaped.
-systemdunit_DATA = var-endless\\x2dextra.mount
+systemdunit_DATA = \
+	dev-disk-by\\x2dlabel-eos\\x2dswap.swap \
+	var-endless\\x2dextra.mount
 endif
 
 # Needs to be outside systemd conditional or it won't be included.
-EXTRA_DIST += var-endless\x2dextra.mount
+EXTRA_DIST += \
+	dev-disk-by\x2dlabel-eos\x2dswap.swap \
+	var-endless\x2dextra.mount
 
 dist_sbin_SCRIPTS = eos-firstboot eos-extra-resize

--- a/debian/eos-boot-helper.postinst
+++ b/debian/eos-boot-helper.postinst
@@ -1,2 +1,9 @@
 #DEBHELPER#
+
+# dh-systemd and systemctl-204 both get escaping wrong when enabling this
+# unit, so we do it manually
+mkdir -p /etc/systemd/system/"dev-disk-by\x2dlabel-eos\x2dswap.device.wants"
+ln -sf /lib/systemd/system/"dev-disk-by\x2dlabel-eos\x2dswap.swap" \
+	/etc/systemd/system/"dev-disk-by\x2dlabel-eos\x2dswap.device.wants"
+
 update-initramfs -u

--- a/debian/rules
+++ b/debian/rules
@@ -8,3 +8,8 @@ override_dh_auto_configure:
 
 override_dh_systemd_start:
 	dh_systemd_start --no-start
+
+override_dh_systemd_enable:
+	# Only enable firstboot here, not swap, since dh-systemd doesn't
+	# get the escaping right. We enable swap manually in postinst.
+	dh_systemd_enable eos-firstboot.service

--- a/dev-disk-by\x2dlabel-eos\x2dswap.swap
+++ b/dev-disk-by\x2dlabel-eos\x2dswap.swap
@@ -1,0 +1,5 @@
+[Swap]
+What=/dev/disk/by-label/eos-swap
+
+[Install]
+WantedBy=dev-disk-by\x2dlabel-eos\x2dswap.device


### PR DESCRIPTION
Move our swap handling out of fstab and into a systemd unit
where we can control it better.

Now swap is purely optional but will be automatically enabled if/when
the appropriate device node appears.

In addition to automake getting it wrong, dh-systemd and systemd-204
also get escaping wrong when enabling this unit (systemd-215 might do it
better). Enable it manually in postinst.

[endlessm/eos-shell#4778]