### PR TITLE
debian: Cleap old extra resizing wants symlinks

### DIFF
--- a/debian/eos-boot-helper.postinst
+++ b/debian/eos-boot-helper.postinst
@@ -6,4 +6,14 @@ mkdir -p /etc/systemd/system/"dev-disk-by\x2dlabel-eos\x2dswap.device.wants"
 ln -sf /lib/systemd/system/"dev-disk-by\x2dlabel-eos\x2dswap.swap" \
 	/etc/systemd/system/"dev-disk-by\x2dlabel-eos\x2dswap.device.wants"
 
+# Previous versions of eos-boot-helper installed wants symlinks for some
+# of the services performing the extra storage resizing. Only the
+# local-fs.target.wants/endless.mount symlink is actually needed.
+# Cleanup the old links, trying to handle improperly escaped files, too.
+rm -rf "/etc/systemd/system/systemd-fsck@dev-disk-by\x2dlabel-extra.service.wants" \
+	/etc/systemd/system/systemd-fsck@dev-disk-byx2dlabel-extra.service.wants
+rm -f /etc/systemd/system/local-fs.target.wants/eos-extra-resize.service
+rm -f "/etc/systemd/system/local-fs.target.wants/var-endless\x2dextra.mount" \
+	/etc/systemd/system/local-fs.target.wants/var-endlessx2dextra.mount
+
 update-initramfs -u


### PR DESCRIPTION
Previous iterations of the extra storage resizing services were creating
wants symlinks in /etc/systemd/system to trigger resizing and mounting
on boot. Converted systems without extra storage are now getting boot
delays when these wants chains are enabled.

All that's required for this currently is the
local-fs.target.wants/endless.mount symlink, which is created in the
image builder for split disk images. Remove any old remnants after
installing users upgrading on converted systems.

[endlessm/eos-shell#4880]