### PR TITLE
Mount /endless overlayfs when directory doesn't exist

### DIFF
--- a/endless.mount
+++ b/endless.mount
@@ -6,7 +6,6 @@ Conflicts=umount.target
 Before=umount.target
 Before=local-fs.target
 ConditionPathIsDirectory=/var/endless-extra
-ConditionPathIsDirectory=/endless
 ConditionPathIsSymbolicLink=!/endless
 
 # Overlay mount dependencies. It would be nice to use RequiresMountsFor


### PR DESCRIPTION
After an ostree upgrade, the /endless mount point directory will be
gone. In that case, we still want systemd to create the directory and
mount the overlayfs there. It will create the mount point if nothing
exists there.

The other 2 conditions remain. The check for /var/endless-extra should
ensure this only runs on split disk units. The check for /endless not
being a symlink should make sure that if the tmpfiles symlink pointing
to /var/endless was somehow created that we don't try to mount a
recursive overlayfs over it.

[endlessm/eos-shell#4912]