### PR TITLE
Drop CHS sfdisk args, no longer available

### DIFF
--- a/dracut/repartition/endless-repartition.sh
+++ b/dracut/repartition/endless-repartition.sh
@@ -100,7 +100,7 @@ if [ $new_size -gt $part_size ]; then
   udevadm settle
 
   echo "Try to resize $root_part to fill $new_size sectors"
-  echo ",$new_size,," | sfdisk --force --no-reread -N2 -uS -S 32 -H 32 $root_disk
+  echo ",$new_size,," | sfdisk --force --no-reread -N2 $root_disk
   echo "sfdisk returned $?"
   udevadm settle
 fi
@@ -108,7 +108,7 @@ fi
 if [ -n "$swap_start" ]; then
   # Create swap partition
   echo "Create swap partition at $swap_start"
-  echo "$swap_start,+,S," | sfdisk --force --no-reread -N3 -uS -S 32 -H 32 $root_disk
+  echo "$swap_start,+,S," | sfdisk --force --no-reread -N3 $root_disk
   echo "sfdisk returned $?"
   udevadm settle
 fi

--- a/eos-extra-resize
+++ b/eos-extra-resize
@@ -44,7 +44,7 @@ if [ "$marker" = "dd" ]; then
     part_start=$(< /sys/class/block/$extra_part_name/start)
 
     echo "Try to resize $extra_part at sector $part_start to fill $extra_disk"
-    echo "$part_start" | sfdisk --force --no-reread -S 32 -H 32 -uS $extra_disk
+    echo "$part_start" | sfdisk --force --no-reread $extra_disk
     echo "sfdisk returned $?"
 
     # Remove the marker so that repartitioning does not run again.


### PR DESCRIPTION
util-linux-2.26 removes the -S and -H args from sfdisk.
-uS still exists but is redundant (it only accepts sector addressing now),
so I removed that too.

[endlessm/eos-shell#5261]