### PR TITLE
Use upstream 'overlay' filesystem

### DIFF
--- a/endless-mount-dirs.service
+++ b/endless-mount-dirs.service
@@ -1,8 +1,8 @@
-# Ensure /var/endless and /var/endless-extra exist prior to mounting
-# /var/endless-extra or the overlay at /endless. This is required for
-# single disk unit upgrades where /var/endless-extra doesn't exist. It's
-# also good practice to ensure the mount points exist like systemd would
-# do if /endless was a non-overlayfs mount.
+# Ensure /var/endless, /var/endless-extra and /var/endless-workdir exist prior
+# to mounting /var/endless-extra or the overlay at /endless. This is required
+# for single disk unit upgrades where /var/endless-extra doesn't exist. It's
+# also good practice to ensure the mount points exist like systemd would do if
+# /endless was a non-overlayfs mount.
 #
 # This would best be done with tmpfiles.d, but that runs too late after
 # local-fs.target.
@@ -25,9 +25,10 @@ RequiresMountsFor=/var
 # Only run if the directories don't exist
 ConditionPathIsDirectory=|!/var/endless
 ConditionPathIsDirectory=|!/var/endless-extra
+ConditionPathIsDirectory=|!/var/endless-workdir
 
 [Service]
 Type=oneshot
 RemainAfterExit=yes
-ExecStart=/bin/mkdir -p /var/endless /var/endless-extra
+ExecStart=/bin/mkdir -p /var/endless /var/endless-extra /var/endless-workdir
 ExecStart=-/bin/chown app-manager:app-manager /var/endless /var/endless-extra

--- a/endless.mount
+++ b/endless.mount
@@ -24,8 +24,8 @@ RequiresMountsFor=/var/endless
 [Mount]
 What=endless
 Where=/endless
-Type=overlayfs
-Options=rw,lowerdir=/var/endless-extra,upperdir=/var/endless
+Type=overlay
+Options=rw,lowerdir=/var/endless-extra,upperdir=/var/endless,workdir=/var/endless-workdir
 
 [Install]
 WantedBy=local-fs.target


### PR DESCRIPTION
Ubuntu's Linux 4.1 (a requirement for eos 2.4.0) does not provide the
'overlayfs' filesystem we have been using before the upgrade, but a
compatibility layer implemented on top of the upstream 'overlay'
filesystem (endlessm/linux@a61b539). Since we're moving to a new
codebase in any case, let's just use the upstream version directly.

For both 'overlay' and 'overlayfs' filesystems there is a 'workdir'
mount option that needs to be passed to rw mounts.

[endlessm/eos-shell#4518]