### PR TITLE
Install udev rules for Meson video decoder

### DIFF
--- a/50-meson-vdec.rules
+++ b/50-meson-vdec.rules
@@ -1,0 +1,1 @@
+SUBSYSTEM=="video4linux", ATTR{name}=="meson-vdec", SYMLINK+="mfc-dec meson-vdec"

--- a/Makefile.am
+++ b/Makefile.am
@@ -16,6 +16,9 @@ dist_systemdunit_DATA = \
 systemdunit_DATA = \
 	dev-disk-by\\x2dlabel-eos\\x2dswap.swap \
 	var-endless\\x2dextra.mount
+
+udevrulesdir=/lib/udev/rules.d
+dist_udevrules_DATA = 50-meson-vdec.rules
 endif
 
 # Needs to be outside systemd conditional or it won't be included.


### PR DESCRIPTION
Chromium looks for the V4L2 video decoder at /dev/mfc-dec. Add
an appropriate symlink for the Meson platform, plus a more appropriate
"meson-vdec" link.

[endlessm/eos-shell#5226]