### PR TITLE
Fixes for app mounts

### DIFF
--- a/debian/eos-boot-helper.postinst
+++ b/debian/eos-boot-helper.postinst
@@ -7,9 +7,8 @@ ln -sf /lib/systemd/system/"dev-disk-by\x2dlabel-eos\x2dswap.swap" \
 	/etc/systemd/system/"dev-disk-by\x2dlabel-eos\x2dswap.device.wants"
 
 # Previous versions of eos-boot-helper installed wants symlinks for some
-# of the services performing the extra storage resizing. Only the
-# local-fs.target.wants/endless.mount symlink is actually needed.
-# Cleanup the old links, trying to handle improperly escaped files, too.
+# of the services performing the extra storage resizing. Cleanup the old
+# links, trying to handle improperly escaped files, too.
 rm -rf "/etc/systemd/system/systemd-fsck@dev-disk-by\x2dlabel-extra.service.wants" \
 	/etc/systemd/system/systemd-fsck@dev-disk-byx2dlabel-extra.service.wants
 rm -f /etc/systemd/system/local-fs.target.wants/eos-extra-resize.service

--- a/debian/rules
+++ b/debian/rules
@@ -13,6 +13,5 @@ override_dh_systemd_start:
 # escaping right. We enable swap manually in postinst.
 override_dh_systemd_enable:
 	dh_systemd_enable eos-firstboot.service
-	dh_systemd_enable endless.mount
 	dh_systemd_enable eos-enable-extra-upgrade.service
 	dh_systemd_enable boot.mount

--- a/eos-enable-extra-upgrade
+++ b/eos-enable-extra-upgrade
@@ -39,17 +39,8 @@ is_split_unit()
     esac
 }
 
-# Exit if the stamp file exists. The service file checks for this, but
-# also guard against an accidental execution.
-stamp_dir=/var/lib/eos-boot-helper
-stamp_file="$stamp_dir/eos-enable-extra-upgrade"
-[ -f "$stamp_file" ] && exit 0
-
-mkdir -p "$stamp_dir"
-
-# Create the stamp file and exit if this is not a split unit
+# Exit if this is not a split unit
 if ! is_split_unit; then
-    touch "$stamp_file"
     echo "Not split disk unit, exiting"
     exit 0
 fi
@@ -58,7 +49,6 @@ fi
 wants_dir=/etc/systemd/system/local-fs.target.wants
 wants_link="$wants_dir/var-endless\x2dextra.mount"
 if [ -e "$wants_link" ]; then
-    touch "$stamp_file"
     echo "Mount unit already enabled or masked at $wants_link, exiting"
     exit 0
 fi
@@ -72,9 +62,6 @@ fi
 echo "Statically enabling mount unit at $wants_link"
 mkdir -p "$wants_dir"
 ln -sf "$mount_unit_path" "$wants_link"
-
-# Done, create the stamp file
-touch "$stamp_file"
 
 # Reload systemd so that the new unit is seen to be enabled
 systemctl daemon-reload

--- a/eos-enable-extra-upgrade
+++ b/eos-enable-extra-upgrade
@@ -79,6 +79,5 @@ touch "$stamp_file"
 # Reload systemd so that the new unit is seen to be enabled
 systemctl daemon-reload
 
-# Restart endless.mount so it uses the now (hopefully) mounted SD card
+# Start the unit now so that the SD card (hopefully) gets mounted
 systemctl start "$mount_unit"
-systemctl restart endless.mount

--- a/eos-enable-extra-upgrade.service
+++ b/eos-enable-extra-upgrade.service
@@ -3,14 +3,12 @@
 
 [Unit]
 Description=Enable Endless extra storage mount on upgrade
-# Need DefaultDependencies=no so basic.target is not required
+# Need DefaultDependencies=no so sysinit.target is not required
 DefaultDependencies=no
-After=sysinit.target local-fs.target
-Before=basic.target
-
-# Skip if this has already been run
-RequiresMountsFor=/var/lib/eos-boot-helper
-ConditionPathExists=!/var/lib/eos-boot-helper/eos-enable-extra-upgrade
+Conflicts=shutdown.target
+After=local-fs.target
+Before=sysinit.target shutdown.target systemd-update-done.service
+ConditionNeedsUpdate=/etc
 
 [Service]
 Type=oneshot

--- a/eos-extra-resize.service
+++ b/eos-extra-resize.service
@@ -10,7 +10,6 @@ After=dev-disk-by\x2dlabel-extra.device
 Requires=dev-disk-by\x2dlabel-extra.device
 Before=var-endless\x2dextra.mount
 Before=systemd-fsck@dev-disk-by\x2dlabel-extra.service
-ConditionPathIsDirectory=/var/endless-extra
 ConditionPathExists=!/var/eos-extra-resize
 
 [Service]

--- a/var-endless\x2dextra.mount
+++ b/var-endless\x2dextra.mount
@@ -3,7 +3,6 @@ After=ostree-remount.service
 After=eos-extra-resize.service
 Wants=eos-extra-resize.service
 Before=local-fs.target
-ConditionPathIsDirectory=/var/endless-extra
 
 [Mount]
 What=/dev/disk/by-label/extra

--- a/var-endless\x2dextra.mount
+++ b/var-endless\x2dextra.mount
@@ -3,6 +3,8 @@ After=ostree-remount.service
 After=eos-extra-resize.service
 Wants=eos-extra-resize.service
 Before=local-fs.target
+RequiresOverridable=systemd-fsck@dev-disk-by\x2dlabel-extra.service
+After=systemd-fsck@dev-disk-by\x2dlabel-extra.service
 
 [Mount]
 What=/dev/disk/by-label/extra

--- a/var-endless\x2dextra.mount
+++ b/var-endless\x2dextra.mount
@@ -9,4 +9,3 @@ ConditionPathIsDirectory=/var/endless-extra
 What=/dev/disk/by-label/extra
 Where=/var/endless-extra
 Type=ext4
-Options=ro


### PR DESCRIPTION
Some fixes to make app mounts of /var/endless and /var/endless-extra work better.

[endlessm/eos-shell#5414]