### PR TITLE
eos-enable-extra-upgrade: Only run when /var/eos-extra-resize exists

### DIFF
--- a/eos-enable-extra-upgrade
+++ b/eos-enable-extra-upgrade
@@ -45,6 +45,13 @@ if ! is_split_unit; then
     exit 0
 fi
 
+# Someone may have installed the single disk image on a unit with the
+# extra SD card.
+if [ ! -f /var/eos-extra-resize ]; then
+    echo "Extra filesystem not resized, assuming single disk image, exiting"
+    exit 0
+fi
+
 # Exit if the the wants symlink is already created
 wants_dir=/etc/systemd/system/local-fs.target.wants
 wants_link="$wants_dir/var-endless\x2dextra.mount"

--- a/eos-enable-extra-upgrade.service
+++ b/eos-enable-extra-upgrade.service
@@ -10,6 +10,9 @@ After=local-fs.target
 Before=sysinit.target shutdown.target systemd-update-done.service
 ConditionNeedsUpdate=/etc
 
+# Only run on units that have resized the extra filesystem
+ConditionPathExists=/var/eos-extra-resize
+
 [Service]
 Type=oneshot
 RemainAfterExit=yes


### PR DESCRIPTION
If someone used the single disk image on the EC-200, then the extra
mount unit should not be enabled. Use the presence of
/var/eos-extra-resize to signal that the extra filesystem has been
created and should be mounted.

[endlessm/eos-shell#5481]