### PR TITLE
Don't try to load zram if it is already loaded

### DIFF
--- a/eos-enable-zram
+++ b/eos-enable-zram
@@ -17,7 +17,9 @@ ram_size_kb=$(awk '/MemTotal/{print $2}' /proc/meminfo)
 
 if [ "$ram_size_kb" -le "$th_kb" ]; then
 	if [ "${1:-0}" -ne 0 ]; then
-		modprobe zram
+		if [ ! -e /sys/block/zram0 ]; then
+			modprobe zram
+		fi
 		echo $1M > /sys/block/zram0/disksize
 		mkswap /dev/zram0
 		swapon /dev/zram0


### PR DESCRIPTION
This impacts current development kernels which have everything built-in
and therefore lack the 'zram' module.

[endlessm/eos-shell#6376]