### PR TITLE
endless-repartition: update for new root fsck service

### DIFF
--- a/dracut/repartition/endless-repartition.service
+++ b/dracut/repartition/endless-repartition.service
@@ -10,7 +10,7 @@ ConditionPathExists=/etc/initrd-release
 # wait for the root device to be ready, but avoid running at the same time
 # as fsck.
 After=dev-disk-by\x2dlabel-ostree.device
-Before=systemd-fsck@dev-disk-by\x2dlabel-ostree.service
+Before=systemd-fsck-root.service
 
 [Service]
 Type=oneshot


### PR DESCRIPTION
systemd-229 includes a special condition where it generates the fsck
unit with name "systemd-fsck-root.service" if we are in the initramfs
and dealing with /sysroot.

Update our dependencies accordingly to fix a sequencing problem during
boot.

https://phabricator.endlessm.com/T11323