### PR TITLE
repartition: detect root device from systemd

### DIFF
--- a/dracut/repartition/endless-repartition.service
+++ b/dracut/repartition/endless-repartition.service
@@ -7,10 +7,9 @@ Before=initrd-root-fs.target sysroot.mount
 After=dracut-pre-mount.service
 ConditionPathExists=/etc/initrd-release
 
-# wait for the root device to be ready, but avoid running at the same time
-# as fsck.
-After=dev-disk-by\x2dlabel-ostree.device
-Before=systemd-fsck-root.service
+# Avoid running at the same time as fsck, and also use that unit's completion
+# as a synchronization point to know that the root device is ready.
+After=systemd-fsck-root.service
 
 [Service]
 Type=oneshot

--- a/dracut/repartition/endless-repartition.sh
+++ b/dracut/repartition/endless-repartition.sh
@@ -29,8 +29,15 @@
 #
 # Based on code from dracut-modules-olpc.
 
+root_part=$(systemctl show -p What sysroot.mount)
+root_part=${root_part#What=}
+if [ -z "${root_part}" ]; then
+  echo "repartition: couldn't identify root device"
+  exit 0
+fi
+
 # Identify root partition device node and parent disk
-root_part=$(readlink -f /dev/disk/by-label/ostree)
+root_part=$(readlink -f "${root_part}")
 if [ -z ${root_part} ]; then
   echo "repartition: no root found"
   exit 0


### PR DESCRIPTION
To move away from having the root filesystem always identifed by a fixed
label, update endless-repartition.sh to query sysroot.mount for the root
device.

That introduces a complication in the service file, we can no longer
order after a fixed device such as dev-disk-by\x2dlabel-ostree.device.

To make this unit run after the root device becomes available, but before
fscking it, we would have to likely modify systemd's generators so that
the availability of the root device triggers a new target, which
endless-repartition could be a part of.

But there's no strong requirement for us to run before fsck. We can
instead run after fsck, at which point the root device is guaranteed to
be ready.

https://phabricator.endlessm.com/T11392