### PR TITLE
T11157: Install and enable sysroot-boot.mount

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -6,6 +6,7 @@ systemdunitdir=/lib/systemd/system
 dist_systemdunit_DATA = \
 	eos-firstboot.service \
 	eos-extra-resize.service \
+	sysroot-boot.mount \
 	boot.mount \
 	eos-enable-extra-upgrade.service \
 	eos-enable-zram.service \

--- a/debian/rules
+++ b/debian/rules
@@ -14,5 +14,6 @@ override_dh_systemd_start:
 override_dh_systemd_enable:
 	dh_systemd_enable eos-firstboot.service
 	dh_systemd_enable eos-enable-extra-upgrade.service
+	dh_systemd_enable sysroot-boot.mount
 	dh_systemd_enable boot.mount
 	dh_systemd_enable eos-enable-zram


### PR DESCRIPTION
On 8bcfe86e6b68c24f8d6f00114152e3fe7b7f688a we created a new unit to
mount the "ostree-boot" partition on /sysroot/boot on systems that ship
a separate boot partition, but we forgot to modify the build system to
install this file, and the packaging system to enable this unit on the
final image.

https://phabricator.endlessm.com/T11157