### PR TITLE
repartition: Retrigger initrd.target

### DIFF
--- a/dracut/repartition/endless-repartition.sh
+++ b/dracut/repartition/endless-repartition.sh
@@ -170,3 +170,8 @@ if [ -x /usr/sbin/amlogic-fix-spl-checksum ]; then
   /usr/sbin/amlogic-fix-spl-checksum $root_disk
   udevadm settle
 fi
+
+# During the above process, the rootfs block device momentarily goes away.
+# This sometimes results in systemd cancelling various important parts
+# of the bootup procedure. Retrigger here.
+/bin/systemctl --no-block start initrd.target


### PR DESCRIPTION
Boot often hangs after repartitioning because the recreation of the
block device nodes causes systemd to cancel important parts of the
initramfs boot procedure.

Retriggering initrd.target solves this. Retriggering like this is also
done in other parts of the boot process like in initrd-parse-etc.service.

https://phabricator.endlessm.com/T11323