### PR TITLE
disable eos-swap on eosinstaller images

### DIFF
--- a/dev-disk-by\x2dlabel-eos\x2dswap.swap
+++ b/dev-disk-by\x2dlabel-eos\x2dswap.swap
@@ -1,3 +1,6 @@
+[Unit]
+ConditionPathExists=!/dev/disk/by-label/eosinstaller
+
 [Swap]
 What=/dev/disk/by-label/eos-swap
 


### PR DESCRIPTION
When installing on systems with EOS already installed, this unit enables the swap on the HDD and makes the install fail.

This is for https://phabricator.endlessm.com/T11757 but this isn't actually that useful without https://phabricator.endlessm.com/T11760 which I am also working on.