### PR TITLE
Don't ship a swap unit anymore

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -13,7 +13,6 @@ dist_systemdunit_DATA = \
 # Unfortunately, dist chokes on the escaped \x2d, so we need to
 # split this out into EXTRA_DIST unescaped.
 systemdunit_DATA = \
-	dev-disk-by\\x2dlabel-eos\\x2dswap.swap \
 	var-endless\\x2dextra.mount
 
 udevrulesdir=/lib/udev/rules.d
@@ -22,7 +21,6 @@ endif
 
 # Needs to be outside systemd conditional or it won't be included.
 EXTRA_DIST += \
-	dev-disk-by\x2dlabel-eos\x2dswap.swap \
 	var-endless\x2dextra.mount
 
 dist_sbin_SCRIPTS = \

--- a/debian/eos-boot-helper.postinst
+++ b/debian/eos-boot-helper.postinst
@@ -1,24 +1,14 @@
 #DEBHELPER#
 
-# dh-systemd and systemctl-204 both get escaping wrong when enabling this
-# unit, so we do it manually
-mkdir -p /etc/systemd/system/"dev-disk-by\x2dlabel-eos\x2dswap.device.wants"
-ln -sf /lib/systemd/system/"dev-disk-by\x2dlabel-eos\x2dswap.swap" \
-	/etc/systemd/system/"dev-disk-by\x2dlabel-eos\x2dswap.device.wants"
-
-# Previous versions of eos-boot-helper installed wants symlinks for some
-# of the services performing the extra storage resizing. Cleanup the old
-# links, trying to handle improperly escaped files, too.
+# Cleanup old wants symlinks for services we don't ship anymore
 rm -rf "/etc/systemd/system/systemd-fsck@dev-disk-by\x2dlabel-extra.service.wants" \
 	/etc/systemd/system/systemd-fsck@dev-disk-byx2dlabel-extra.service.wants
 rm -f /etc/systemd/system/local-fs.target.wants/eos-extra-resize.service
 rm -f "/etc/systemd/system/local-fs.target.wants/var-endless\x2dextra.mount" \
 	/etc/systemd/system/local-fs.target.wants/var-endlessx2dextra.mount
-
-# Remove wants symlinks for sysroot-boot.mount and boot.mount, which we do not
-# ship anymore
 rm -f /etc/systemd/system/local-fs.target.wants/sysroot-boot.mount
 rm -f /etc/systemd/system/local-fs.target.wants/boot.mount
+rm -f /etc/systemd/system/"dev-disk-by\x2dlabel-eos\x2dswap.device.wants"
 
 # Ensure /endless is owned by app-manager. The permissions could be set
 # in the package, but that wouldn't fix an existing /endless directory.

--- a/debian/rules
+++ b/debian/rules
@@ -8,10 +8,3 @@ override_dh_auto_configure:
 
 override_dh_systemd_start:
 	dh_systemd_start --no-start
-
-# Enable all units here, except swap, since dh-systemd doesn't get the
-# escaping right. We enable swap manually in postinst.
-override_dh_systemd_enable:
-	dh_systemd_enable eos-firstboot.service
-	dh_systemd_enable eos-enable-extra-upgrade.service
-	dh_systemd_enable eos-enable-zram

--- a/dev-disk-by\x2dlabel-eos\x2dswap.swap
+++ b/dev-disk-by\x2dlabel-eos\x2dswap.swap
@@ -1,8 +1,0 @@
-[Unit]
-ConditionPathExists=!/dev/disk/by-label/eosinstaller
-
-[Swap]
-What=/dev/disk/by-label/eos-swap
-
-[Install]
-WantedBy=dev-disk-by\x2dlabel-eos\x2dswap.device


### PR DESCRIPTION
Recent systemd (229+) GPT generator automatically detects and activates
swap partitions on the same device the system has booted from, so we
don't need to ship a swap unit.

https://phabricator.endlessm.com/T11761