### PR TITLE
robustness: initial implementation

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -8,6 +8,7 @@ dist_systemdunit_DATA = \
 	eos-extra-resize.service \
 	eos-enable-extra-upgrade.service \
 	eos-enable-zram.service \
+	eos-setgoodroot.service \
 	$(NULL)
 
 # Unfortunately, dist chokes on the escaped \x2d, so we need to
@@ -18,6 +19,9 @@ systemdunit_DATA = \
 
 udevrulesdir=/lib/udev/rules.d
 dist_udevrules_DATA = 50-meson-vdec.rules
+
+dbussystemservicedir=/usr/share/dbus-1/system-services
+dist_dbussystemservice_DATA = com.endlessm.SetGoodRoot.service
 endif
 
 # Needs to be outside systemd conditional or it won't be included.
@@ -30,4 +34,8 @@ dist_sbin_SCRIPTS = \
 	eos-extra-resize \
 	eos-enable-extra-upgrade \
 	eos-enable-zram \
+	eos-setgoodroot \
 	$(NULL)
+
+autostartdir = $(sysconfdir)/xdg/autostart
+dist_autostart_DATA = com.endlessm.SetGoodRoot.desktop

--- a/com.endlessm.SetGoodRoot.desktop
+++ b/com.endlessm.SetGoodRoot.desktop
@@ -1,0 +1,6 @@
+[Desktop Entry]
+Name=Set Good Root
+Exec=dbus-send --system --type=method_call --dest=org.freedesktop.DBus /org/freedesktop/DBus org.freedesktop.DBus.StartServiceByName string:"com.endlessm.SetGoodRoot" uint32:0
+Type=Application
+NoDisplay=true
+X-GNOME-Autostart-enabled=true

--- a/com.endlessm.SetGoodRoot.service
+++ b/com.endlessm.SetGoodRoot.service
@@ -1,0 +1,5 @@
+[D-BUS Service]
+Name=com.endlessm.SetGoodRoot
+Exec=/usr/sbin/eos-setgoodroot
+User=root
+SystemdService=eos-setgoodroot.service

--- a/configure.ac
+++ b/configure.ac
@@ -11,5 +11,6 @@ AM_CONDITIONAL(ENABLE_SYSTEMD, [test "$enable_systemd" = yes])
 AC_CONFIG_FILES([
 	Makefile
 	dracut/Makefile
-	dracut/repartition/Makefile])
+	dracut/repartition/Makefile
+	dracut/robustness/Makefile])
 AC_OUTPUT

--- a/dracut/Makefile.am
+++ b/dracut/Makefile.am
@@ -1,4 +1,4 @@
-SUBDIRS = repartition
+SUBDIRS = repartition robustness
 
 dracutconfdir = $(sysconfdir)/dracut.conf.d
 dist_dracutconf_DATA = endless.conf

--- a/dracut/endless.conf
+++ b/dracut/endless.conf
@@ -1,3 +1,3 @@
-dracutmodules="dracut-systemd systemd-initrd dash drm eos-repartition plymouth kernel-modules resume ostree systemd base fs-lib"
+dracutmodules="dracut-systemd systemd-initrd dash drm eos-repartition eos-robustness plymouth kernel-modules resume ostree systemd base fs-lib"
 fscks="fsck fsck.ext4"
 filesystems="ext4"

--- a/dracut/robustness/Makefile.am
+++ b/dracut/robustness/Makefile.am
@@ -1,0 +1,3 @@
+dracutmoddir = $(prefix)/lib/dracut/modules.d/50eos-robustness
+dist_dracutmod_SCRIPTS = module-setup.sh endless-robustness.sh
+dist_dracutmod_DATA = endless-robustness.service

--- a/dracut/robustness/endless-robustness.service
+++ b/dracut/robustness/endless-robustness.service
@@ -1,0 +1,12 @@
+[Unit]
+Description=EOS robustness
+ConditionPathExists=/etc/initrd-release
+
+DefaultDependencies=no
+Before=dracut-pre-pivot.service
+After=initrd-fs.target
+
+[Service]
+Type=oneshot
+ExecStart=-/bin/endless-robustness
+RemainAfterExit=yes

--- a/dracut/robustness/endless-robustness.sh
+++ b/dracut/robustness/endless-robustness.sh
@@ -1,0 +1,254 @@
+#!/bin/sh
+# Copyright (C) 2016 Endless Mobile, Inc.
+# Licensed under the GPLv2
+#
+# The purpose of this script is to make sure we boot a good rootfs.
+
+bootloader_entries_dir="/sysroot/boot/loader/entries"
+extensions_path="/sysroot/ostree/repo/extensions/eos"
+uenv_path="/sysroot/boot/loader/uEnv.txt"
+tmp_dir="${extensions_path}/tmp"
+
+# read_cmdline_ostree reads the kernel command line and extracts the value of
+# the "ostree" parameter.
+#
+# $1: kernel command line
+# $2: the value of the "ostree" parameter (output variable)
+read_cmdline_ostree () {
+    local cmdline="${1}"
+    local __output_var=${2}
+
+    local link
+
+    for p in ${cmdline}; do
+        if [ "$(echo ${p} | cut -d= -f1)" = "ostree" ]; then
+            link=$(echo ${p} | cut -d= -f2-)
+            if [ -n ${link} ]; then
+                eval $__output_var="'${link}'"
+                return 0
+            fi
+        fi
+    done
+
+    return 1
+}
+
+# get_deployment_hash returns the kernel/initramfs hash of a deployment.
+#
+# $1: path of the deployment's root filesystem
+# $2: the kernel/initramfs hash (output variable)
+get_deployment_hash () {
+    local rootfs=${1}
+    local __output_var=${2}
+
+    local deployment_hash
+
+    for f in $(ls ${rootfs}/boot); do
+        if [ $(echo ${f} | cut -d- -f1) = "vmlinuz" ]; then
+            vmlinuz_hash=$(echo ${f} | rev | cut -d- -f1 | rev)
+        elif [ $(echo ${f} | cut -d- -f1) = "initramfs" ]; then
+            initramfs_hash=$(echo ${f} | rev | cut -d- -f1 | rev)
+        fi
+    done
+    if [ -z ${vmlinuz_hash} -o -z ${initramfs_hash} -o ${vmlinuz_hash} != ${initramfs_hash} ]; then
+        echo "robustness: missing or conflicting values for kernel and initramfs hashes"
+        return 1
+    fi
+
+    deployment_hash=${vmlinuz_hash}
+
+    eval $__output_var="'${deployment_hash}'"
+    return 0
+}
+
+# get_bootloader_entry returns the path to the bootloader entry of the
+# deployment that has a particular kernel/initramfs hash.
+#
+# $1: kernel/initramfs hash
+# $2: the path to the bootloader entry containing the deployment (output variable)
+get_bootloader_entry () {
+    local deployment_hash=${1}
+    local __output_var=${2}
+
+    local bootloader_entry
+
+    for f in "${bootloader_entries_dir}"/*; do
+        if [ $(grep -c ${deployment_hash} ${f}) -gt 0 ]; then
+            if [ -z ${bootloader_entry} ]; then
+                bootloader_entry=${f}
+            else
+                echo "robustness: more than one bootloader entry with the same deployment hash"
+                return 1
+            fi
+        fi
+    done
+
+    if [ -z ${bootloader_entry} ]; then
+        echo "robustness: bootloader entry not found for hash ${deployment_hash}"
+        return 1
+    fi
+
+    eval $__output_var=${bootloader_entry}
+    return 0
+}
+
+# swap_files swaps two files on disk.
+#
+# $1: file 1
+# $2: file 2
+swap_files () {
+    if [ ! -f ${1} ]; then
+        echo "robustness: file ${1} doesn't exist"
+        return 1
+    fi
+    if [ ! -f ${2} ]; then
+        echo "robustness: file ${2} doesn't exist"
+        return 1
+    fi
+
+    temp=$(mktemp -p $(dirname ${1}))
+    mv ${1} ${temp} && \
+        mv ${2} ${1} && \
+        mv ${temp} ${2}
+    if [ $? != 0 ]; then
+        echo "robustness: error swapping files ${1} and ${2}"
+        return 1
+    fi
+
+    return 0
+}
+
+
+read_cmdline_ostree "$(cat /proc/cmdline)" new_ostree_link
+if [ $? != 0 ]; then
+    echo "robustness: missing ostree parameter in kernel command line"
+    exit 0
+fi
+new_deployment_link=/sysroot${new_ostree_link}
+
+new_deployment_link_target=$(readlink ${new_deployment_link})
+new_root=$(basename ${new_deployment_link_target})
+new_root_path=$(readlink -f ${new_deployment_link})
+
+deploys_directory=$(dirname ${new_root_path})
+
+# check the bootloader entries to find the old root
+for cfg_path in "${bootloader_entries_dir}"/*; do
+    cfg=$(basename ${cfg_path})
+    # check that the bootloader file starts with "ostree" and ends with ".conf"
+    #   $ basename foo.conf .conf
+    #   foo
+    #   $ basename foo.confs .conf
+    #   foo.confs
+    if [ $(echo ${cfg} | cut -d- -f1) = "ostree" -a $(basename ${cfg} .conf) != ${cfg} ]; then
+        read_cmdline_ostree "$(grep "ostree=" ${cfg_path})" ostree_link
+        if [ $? != 0 ]; then
+            echo "robustness: entry without ostree parameter in ${entries_dir}"
+            exit 0
+        fi
+        if [ ${ostree_link} != ${new_ostree_link} ]; then
+            old_deployment_link=/sysroot${ostree_link}
+            old_deployment_link_target=$(readlink ${old_deployment_link})
+            old_root=$(basename ${old_deployment_link_target})
+            break
+        fi
+    fi
+done
+
+if [ -z ${old_root} ]; then
+    echo "robustness: only one bootloader entry, booting it"
+    exit 0
+fi
+
+old_root_hash=$(echo ${old_root} | cut -d "." -f 1)
+new_root_hash=$(echo ${new_root} | cut -d "." -f 1)
+
+old_root_path=${deploys_directory}/${old_root}
+
+# check new root successful state
+new_root_flags_path="${extensions_path}/boot-flags/${new_root_hash}"
+
+if [ -f ${new_root_flags_path} ]; then
+    # skip first line [boot-flags]
+    for l in $(tail -n+2 ${new_root_flags_path}); do
+        key="$(echo ${l} | cut -d= -f1)"
+        value="$(echo ${l} | cut -d= -f2-)"
+        case "${key}" in
+            successful)
+                successful="${value}"
+                ;;
+            tries_left)
+                tries_left="${value}"
+                ;;
+            *)
+                echo "robustness: malformed line in flags file: ${l}"
+        esac
+    done
+
+    if [ -z ${successful} -o -z ${tries_left} ]; then
+        echo "robustness: failed to parse flags file, booting the root specified in the kernel command line"
+        exit 0
+    fi
+
+    echo successful=${successful}
+    echo tries_left=${tries_left}
+
+    if [ ${successful} = 1 ]; then
+        # last boot successful, we can just boot
+        # no need for the flags file anymore, we can delete it
+        rm -f ${new_root_flags_path}
+    elif [ ${tries_left} -gt 0 ]; then
+        # first boot with an updated tree or last boot not successful but we
+        # still have tries left, decrement tries_left and boot
+        tries_left_updated=$((${tries_left} - 1))
+        sed -i "s/tries_left=${tries_left}/tries_left=${tries_left_updated}/g" ${new_root_flags_path}
+    else
+        echo "Last boot unsuccessful and no more tries left, rolling back to previous version"
+        get_deployment_hash ${new_root_path} new_deployment_hash
+        if [ $? != 0 ]; then
+            exit 0
+        fi
+        get_deployment_hash ${old_root_path} old_deployment_hash
+        if [ $? != 0 ]; then
+            exit 0
+        fi
+        get_bootloader_entry ${old_deployment_hash} old_bootloader_entry
+        if [ $? != 0 ]; then
+            exit 0
+        fi
+        get_bootloader_entry ${new_deployment_hash} new_bootloader_entry
+        if [ $? != 0 ]; then
+            exit 0
+        fi
+
+        mkdir -p ${tmp_dir}
+        cat /proc/cmdline > ${tmp_dir}/cmdline
+        sed -i "s/${new_deployment_hash}/${old_deployment_hash}/g" ${tmp_dir}/cmdline
+
+        swap_files ${new_bootloader_entry} ${old_bootloader_entry}
+        if [ $? != 0 ]; then
+            exit 0
+        fi
+
+        if [ -f ${uenv_path} ]; then
+            sed -i "s/${new_deployment_hash}/${old_deployment_hash}/g" ${uenv_path}
+        fi
+
+        # ostree uses "version" to decide whether to swap bootloader
+        # configurations when doing a deploy, make sure the rolled-back
+        # deployment has version 1. This allows deploying again the just
+        # rolled-back deployment
+        sed -i "s/^version [0-9]$/version 1/" ${old_bootloader_entry}
+        sed -i "s/^version [0-9]$/version 2/" ${new_bootloader_entry}
+
+        # signal userspace we rolled back so it can clean up and inform the
+        # user
+        echo ${new_root_hash} > ${extensions_path}/rolled-back
+
+        # change /proc/cmdline so ostree reads the right value of "ostree=" on
+        # this boot
+        mount --bind ${tmp_dir}/cmdline /proc/cmdline
+    fi
+else
+    echo "robustness: missing flags file, booting the root specified in the kernel command line"
+fi

--- a/dracut/robustness/module-setup.sh
+++ b/dracut/robustness/module-setup.sh
@@ -1,0 +1,28 @@
+# Copyright (C) 2016 Endless Mobile, Inc.
+# Licensed under the GPLv2
+
+check() {
+  return 0
+}
+
+depends() {
+  echo systemd
+}
+
+install() {
+  dracut_install basename
+  dracut_install cut
+  dracut_install dirname
+  dracut_install grep
+  dracut_install mktemp
+  dracut_install readlink
+  dracut_install rev
+  dracut_install sed
+  dracut_install tail
+  inst_script "$moddir/endless-robustness.sh" /bin/endless-robustness
+  inst_simple "$moddir/endless-robustness.service" \
+	"$systemdsystemunitdir/endless-robustness.service"
+  mkdir -p "${initdir}/$systemdsystemunitdir/initrd.target.wants"
+  ln_r "$systemdsystemunitdir/endless-robustness.service" \
+	"$systemdsystemunitdir/initrd.target.wants/endless-robustness.service"
+}

--- a/eos-setgoodroot
+++ b/eos-setgoodroot
@@ -1,0 +1,49 @@
+#!/bin/sh
+# Copyright (C) 2016 Endless Mobile, Inc.
+# Licensed under the GPLv2
+#
+# The purpose of this script is mark a booted update as successful and clean up
+# failed boots.
+
+set -e
+
+extensions_path="/sysroot/ostree/repo/extensions/eos"
+deployment_regex='eos [[:alnum:]]{64}\.[[:digit:]]'
+
+booted_hash=$(ostree admin status | grep -E "[*] ${deployment_regex}" | cut -d' ' -f3 | cut -d. -f1)
+
+boot_flags_path="${extensions_path}/boot-flags/${booted_hash}"
+
+# XXX maybe just remove flags file? It will make the system boot anyway
+if [ -f "${boot_flags_path}" ]; then
+    echo "Setting current booted deployment as good"
+    cat <<EOF > "${boot_flags_path}"
+[boot-flags]
+successful=1
+tries_left=0
+EOF
+fi
+
+rolledback_path="${extensions_path}/rolled-back"
+
+if [ -f "${rolledback_path}" ]; then
+    echo "Detected roll back, undeploying bogus deployment if necessary"
+    hash_to_undeploy="$(cat ${rolledback_path})"
+    i=0
+    for depl in "$(ostree admin status | grep -E "[*| ] ${deployment_regex}")"; do
+        if [ $(echo "${depl}" | grep -c ${hash_to_undeploy}) -gt 0 ]; then
+            idx=${i}
+            break
+        fi
+        i=$((i + 1))
+    done
+
+    if [ -n "${idx}" ]; then
+        ostree admin undeploy ${idx}
+        rm -f "${extensions_path}/boot-flags/${hash_to_undeploy}"
+        rm -rf "${extensions_path}/tmp"
+    fi
+
+    # Remove roll-back file? Probably other tool should warn the user and
+    # remove it if appropriate.
+fi

--- a/eos-setgoodroot.service
+++ b/eos-setgoodroot.service
@@ -1,0 +1,8 @@
+[Unit]
+Description=Endless Set Good Root D-Bus service
+
+[Service]
+Type=dbus
+BusName=com.endlessm.SetGoodRoot
+ExecStart=/usr/sbin/eos-setgoodroot
+TimeoutStartSec=infinity


### PR DESCRIPTION
This PR adds a dracut service that checks a boot-flags file to decide which
root to boot.
- If there's no flags file for this root, the service will just boot.
- If the "successful" flag is 1, the service will remove the flags file
  and boot, since a previous boot attempt was successful we assume the
  root is good.
- If the "successful" flag is 0 but "tries_left" is >0, it will try to
  boot this root, decreasing "tries_left".
- Finally, if both "successful" and "tries_left" are 0, it will roll
  back to the previous root swapping the bootloader files and setting
  "/proc/cmdline" to the old root. It will also signal userspace by
  creating a "rolled-back" file.

Initially, eos-updater sets this file with "successful=0" and
"tries_left=1" so one boot is attempted. If the user is able to log in,
a DBus service will mark the root as successful (see the following
commit).

It also adds a dbus service that starts on user login
(X-GNOME-Autostart-enabled=true) that sets an updated ostree root as
successful and cleans up rolled back deployments if needed.

XRef endlessm/eos-updater#38 
