### PR TITLE
firstboot: filesystem UUID is now randomized in initramfs

### DIFF
--- a/dracut/repartition/endless-repartition.sh
+++ b/dracut/repartition/endless-repartition.sh
@@ -163,6 +163,12 @@ fi
 
 [ -e "$swap_part" ] && mkswap -L eos-swap $swap_part
 
+# Randomize root filesystem UUID
+# uninit_bg functionality prevents us from doing this later when the
+# filesystem is mounted.
+tune2fs -U random $root_part
+udevadm settle
+
 # Remove marker - must be done last, prevents this script from running again
 sfdisk --force --part-attrs $root_disk $partno ''
 udevadm settle

--- a/dracut/repartition/module-setup.sh
+++ b/dracut/repartition/module-setup.sh
@@ -14,6 +14,7 @@ install() {
   dracut_install readlink
   dracut_install mkswap
   dracut_install sed
+  dracut_install tune2fs
   dracut_install -o amlogic-fix-spl-checksum
   inst_script "$moddir/endless-repartition.sh" /bin/endless-repartition
   inst_simple "$moddir/endless-repartition.service" \

--- a/eos-firstboot
+++ b/eos-firstboot
@@ -6,16 +6,5 @@ root_part=$(findmnt -rvnf -o SOURCE /)
 
 resize2fs "${root_part}"
 
-# Randomize UUID for the root filesystem
-#   uninit_bg checksums depend on the UUID, this prohibits changes to
-#   the UUID if a checksumming filesystem is mounted. Temporarly disable
-#   the feature before changing the UUID
-tune2fs -O ^uninit_bg ${root_part}
-tune2fs -U random ${root_part}
-tune2fs -O +uninit_bg ${root_part}
-
-# Print for debugging
-blkid
-
 > /var/eos-booted
 exit 0


### PR DESCRIPTION
We're facing some strange filesystem corruption on first boot, which
goes away if these commands are commented out.

The tune2fs man page warns about changing uninit_bg:

      After setting or clearing sparse_super, uninit_bg, filetype,  or
      resize_inode  filesystem  features, e2fsck(8) must be run on the
      filesystem to return  the  filesystem  to  a  consistent  state.
      Tune2fs will print a message requesting that the system adminis‐
      trator run e2fsck(8) if necessary.

Things don't quite add up: tune2fs does not ask us to run e2fsck,
the corruption that is seen on first boot is really extensive (not just
related to uninitialized bitmaps), and running these commands manually
later also doesn't cause the problem to come back.

Regardless, seems like doing this here is a bad idea.
We'll move the UUID-randomization to the initramfs, also avoiding the need
to adjust uninit_bg.

https://phabricator.endlessm.com/T12317