### PR TITLE
Support booting from image file on exFAT

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -8,6 +8,7 @@ dist_systemdunit_DATA = \
 	eos-extra-resize.service \
 	eos-enable-extra-upgrade.service \
 	eos-enable-zram.service \
+	eos-live-boot-overlayfs-setup.service \
 	$(NULL)
 
 # Unfortunately, dist chokes on the escaped \x2d, so we need to
@@ -28,4 +29,5 @@ dist_sbin_SCRIPTS = \
 	eos-extra-resize \
 	eos-enable-extra-upgrade \
 	eos-enable-zram \
+	eos-live-boot-overlayfs-setup \
 	$(NULL)

--- a/configure.ac
+++ b/configure.ac
@@ -11,5 +11,6 @@ AM_CONDITIONAL(ENABLE_SYSTEMD, [test "$enable_systemd" = yes])
 AC_CONFIG_FILES([
 	Makefile
 	dracut/Makefile
+	dracut/image-boot/Makefile
 	dracut/repartition/Makefile])
 AC_OUTPUT

--- a/dracut/Makefile.am
+++ b/dracut/Makefile.am
@@ -1,4 +1,4 @@
-SUBDIRS = repartition
+SUBDIRS = repartition image-boot
 
 dracutconfdir = $(sysconfdir)/dracut.conf.d
 dist_dracutconf_DATA = endless.conf

--- a/dracut/endless.conf
+++ b/dracut/endless.conf
@@ -1,3 +1,3 @@
-dracutmodules="dracut-systemd systemd-initrd dash drm eos-repartition plymouth kernel-modules resume ostree systemd base fs-lib"
+dracutmodules="dracut-systemd systemd-initrd dash drm eos-repartition eos-image-boot plymouth kernel-modules resume ostree systemd base fs-lib"
 fscks="fsck fsck.ext4"
 filesystems="ext4"

--- a/dracut/image-boot/Makefile.am
+++ b/dracut/image-boot/Makefile.am
@@ -1,0 +1,3 @@
+dracutmoddir = $(prefix)/lib/dracut/modules.d/50eos-image-boot
+dist_dracutmod_SCRIPTS = module-setup.sh eos-image-boot-setup eos-image-boot-generator
+dist_dracutmod_DATA = eos-image-boot-setup.service eos-live-etc-setup.service

--- a/dracut/image-boot/eos-image-boot-generator
+++ b/dracut/image-boot/eos-image-boot-generator
@@ -1,0 +1,86 @@
+#!/bin/sh
+# Copyright (C) 2016 Endless Mobile, Inc.
+# Licensed under the GPLv2
+#
+# Support booting from an image file hosted on a filesystem.
+# We parse the kernel parameters requesting this functionality and configure
+# other systemd units to go about setting up the block devices and mounting
+# the target filesystem.
+
+type getarg >/dev/null 2>&1 || . /lib/dracut-lib.sh
+
+GENERATOR_DIR="$1"
+
+image_device=$(getarg endless.image.device=)
+image_path=$(getarg endless.image.path=)
+
+[ -z "${image_device}" -o -z "${image_path}" ] && exit 0
+
+case "${image_device}" in
+PARTUUID=*)
+  image_device=/dev/disk/by-partuuid/${image_device#PARTUUID=}
+  ;;
+UUID=*)
+  image_device=/dev/disk/by-uuid/${image_device#UUID=}
+  ;;
+esac
+
+image_device_escaped=$(systemd-escape -p "${image_device}")
+
+# For convenience so that other scripts don't have to parse the cmdline again
+echo "${image_device}" > /var/tmp/endless-image-host
+
+# When the image device appears, run the setup
+mkdir -p ${GENERATOR_DIR}/initrd-fs.target.wants
+ln -s /lib/systemd/system/eos-image-boot-setup.service \
+	${GENERATOR_DIR}/initrd-fs.target.wants
+mkdir -p ${GENERATOR_DIR}/eos-image-boot-setup.service.d
+cat <<EOF >${GENERATOR_DIR}/eos-image-boot-setup.service.d/50-device.conf
+[Unit]
+Requires=${image_device_escaped}.device
+After=${image_device_escaped}.device
+EOF
+
+if getargbool 0 endless.live_boot; then
+  rwflag=ro
+else
+  rwflag=rw
+fi
+
+# Once the actual EOS device has appeared, use the normal infrastructure
+# to fsck and mount it.
+cat <<EOF >${GENERATOR_DIR}/sysroot.mount
+[Unit]
+Before=initrd-root-fs.target
+Requires=systemd-fsck-root.service
+After=systemd-fsck-root.service
+[Mount]
+What=/dev/mapper/endless-image3
+Where=/sysroot
+Options=$rwflag
+EOF
+
+cat <<EOF >${GENERATOR_DIR}/systemd-fsck-root.service
+[Unit]
+DefaultDependencies=no
+BindsTo=dev-mapper-endless\x2dimage3.device
+After=initrd-root-device.target local-fs-pre.target
+Before=shutdown.target
+ConditionKernelCommandLine=!endless.live_boot
+[Service]
+Type=oneshot
+RemainAfterExit=yes
+ExecStart=/lib/systemd/systemd-fsck /dev/mapper/endless-image3
+TimeoutSec=0
+EOF
+
+mkdir -p ${GENERATOR_DIR}/initrd-root-device.target.d
+cat <<EOF >${GENERATOR_DIR}/initrd-root-device.target.d/50-device.conf
+[Unit]
+Requires=dev-mapper-endless\x2dimage3.device
+After=dev-mapper-endless\x2dimage3.device
+EOF
+
+mkdir -p ${GENERATOR_DIR}/initrd-root-fs.target.requires
+ln -s ${GENERATOR_DIR}/sysroot.mount \
+	${GENERATOR_DIR}/initrd-root-fs.target.requires

--- a/dracut/image-boot/eos-image-boot-setup
+++ b/dracut/image-boot/eos-image-boot-setup
@@ -1,0 +1,58 @@
+#!/bin/sh
+# Copyright (C) 2016 Endless Mobile, Inc.
+# Licensed under the GPLv2
+#
+# Support booting from an image file hosted on a filesystem.
+# We identify which disk blocks correspond to the image file, and create
+# a dm-linear block device mapping them.
+
+type getarg >/dev/null 2>&1 || . /lib/dracut-lib.sh
+
+host_device=$(cat /var/tmp/endless-image-host)
+image_path=$(getarg endless.image.path)
+
+blockdev --setro ${host_device}
+
+if getargbool 0 endless.live_boot; then
+  dm_roflag=--readonly
+  kpartx_roflag=-r
+fi
+
+# Identify the EOS image extents on the host device, and create a dm-linear
+# block device that maps exactly to that.
+extents=$(dumpexfat -f "${image_path}" "${host_device}")
+if [ $? != 0 ]; then
+  echo "image-boot: failed to lookup image on device"
+  exit 1
+fi
+
+offset=0
+echo "$extents" | while read extent_offset extent_size; do
+  [ -z "${extent_offset}" -o -z "${extent_size}" ] && continue
+  # Convert bytes to sectors, rounding up
+  if [ $(( extent_size % 512 )) != 0 ]; then
+    echo "image-boot: extent size $extent_size not sector-aligned" >&2
+    exit 1
+  fi
+  extent_size=$(( extent_size / 512 ))
+  extent_offset=$(( extent_offset / 512 ))
+  echo "${offset} ${extent_size} linear ${host_device} $extent_offset"
+  offset=$((offset + extent_size))
+done > /tmp/dmtable
+
+if [ $? != 0 ]; then
+  exit 1
+fi
+
+dmsetup create endless-image $dm_roflag < /tmp/dmtable
+if [ $? != 0 ]; then
+  echo "image-boot: failed to set up linear mapping"
+  exit 1
+fi
+
+if ! kpartx $kpartx_roflag -a -v /dev/mapper/endless-image; then
+  echo "image-boot: failed to probe partitions"
+  exit 1
+fi
+
+exit 0

--- a/dracut/image-boot/eos-image-boot-setup.service
+++ b/dracut/image-boot/eos-image-boot-setup.service
@@ -1,0 +1,11 @@
+# This unit is dynamically enabled by endless-image-boot-generator
+[Unit]
+Description=EndlessOS image boot filesystem setup
+DefaultDependencies=no
+Before=initrd-switch-root.target initrd-fs.target
+ConditionKernelCommandLine=endless.image.device
+
+[Service]
+Type=oneshot
+ExecStart=/bin/eos-image-boot-setup
+RemainAfterExit=yes

--- a/dracut/image-boot/eos-live-etc-setup.service
+++ b/dracut/image-boot/eos-live-etc-setup.service
@@ -1,0 +1,16 @@
+# We need to set up the /etc overlayfs before switch-root. Otherwise there
+# are several problems during early boot like journald not starting.
+[Unit]
+Description=EndlessOS live /etc setup
+DefaultDependencies=no
+After=initrd-switch-root.target
+After=ostree-prepare-root.service
+Before=initrd-switch-root.service
+Before=plymouth-switch-root.service
+ConditionKernelCommandLine=endless.live_boot
+
+[Service]
+Type=oneshot
+ExecStart=/usr/bin/mkdir -p /run/eos-live/etc /run/eos-live/etc-workdir
+ExecStart=/usr/bin/mount -t overlay -o rw,upperdir=/run/eos-live/etc,lowerdir=/sysroot/etc,workdir=/run/eos-live/etc-workdir eos-live-etc /sysroot/etc
+RemainAfterExit=yes

--- a/dracut/image-boot/module-setup.sh
+++ b/dracut/image-boot/module-setup.sh
@@ -1,0 +1,25 @@
+# Copyright (C) 2016 Endless Mobile, Inc.
+# Licensed under the GPLv2
+
+check() {
+  return 0
+}
+
+depends() {
+  echo systemd
+}
+
+install() {
+  dracut_install blockdev kpartx dmsetup dumpexfat
+  instmods overlay
+  inst_rules 55-dm.rules
+  inst_script "$moddir"/eos-image-boot-setup /bin/eos-image-boot-setup
+  inst_simple "$moddir"/eos-image-boot-setup.service \
+	"$systemdsystemunitdir"/eos-image-boot-setup.service
+  inst_simple "$moddir"/eos-live-etc-setup.service \
+	"$systemdsystemunitdir"/eos-live-etc-setup.service
+  mkdir -p "${initdir}${systemdsystemconfdir}/initrd-switch-root.target.wants"
+  ln_r "${systemdsystemunitdir}/eos-live-etc-setup.service" \
+        "${systemdsystemconfdir}/initrd-switch-root.target.wants/eos-live-etc-setup.service"
+  inst_script "$moddir/eos-image-boot-generator" $systemdutildir/system-generators/eos-image-boot-generator
+}

--- a/dracut/repartition/endless-repartition.service
+++ b/dracut/repartition/endless-repartition.service
@@ -1,6 +1,7 @@
 [Unit]
 Description=EOS repartitioning
 ConditionPathExists=/etc/initrd-release
+ConditionKernelCommandLine=!endless.live_boot
 
 # Our position in the boot order is important. Naturally, we need to run
 # after the root device is available, before the root fs is mounted.

--- a/dracut/repartition/module-setup.sh
+++ b/dracut/repartition/module-setup.sh
@@ -11,6 +11,7 @@ depends() {
 
 install() {
   dracut_install sfdisk
+  dracut_install blockdev
   dracut_install readlink
   dracut_install mkswap
   dracut_install sed

--- a/eos-firstboot.service
+++ b/eos-firstboot.service
@@ -6,6 +6,7 @@ DefaultDependencies=no
 After=sysinit.target local-fs.target
 Before=basic.target
 ConditionPathExists=!/var/eos-booted
+ConditionKernelCommandLine=!endless.live_boot
 
 [Service]
 Type=oneshot

--- a/eos-live-boot-overlayfs-setup
+++ b/eos-live-boot-overlayfs-setup
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+# Mount overlays over any directory that might be written to
+# Note that /etc was handled in the initramfs since it must be done early.
+# The rest of these should be done later, to avoid fighting with ostree-remount
+overlay_dirs="bin boot endless home lib opt ostree root sbin srv sysroot var"
+for dir in $overlay_dirs; do
+    [ -d /$dir ] || continue
+    # If the directory is a symlink, assume it's pointing to a location
+    # covered by another top level overlay
+    [ -L /$dir ] && continue
+    mkdir -p /run/eos-live/$dir /run/eos-live/$dir-workdir
+    mount -t overlay -o \
+        rw,upperdir=/run/eos-live/$dir,lowerdir=/$dir,workdir=/run/eos-live/$dir-workdir \
+        eos-live-$dir /$dir
+done
+
+# Disable the updater for this boot
+systemctl stop eos-updater.timer
+systemctl mask --runtime eos-updater.timer

--- a/eos-live-boot-overlayfs-setup.service
+++ b/eos-live-boot-overlayfs-setup.service
@@ -1,0 +1,13 @@
+[Unit]
+Description=Endless live boot overlayfs setup
+DefaultDependencies=no
+After=ostree-remount.service
+Before=local-fs.target
+ConditionKernelCommandLine=endless.live_boot
+
+[Service]
+Type=oneshot
+ExecStart=/usr/sbin/eos-live-boot-overlayfs-setup
+
+[Install]
+WantedBy=local-fs.target


### PR DESCRIPTION
Add infrastructure needed to support booting from an Endless image file
found on an exFAT partition. This is primarily implemented inside the
new eos-image dracut module.

The endless.image.device parameter should be generated by the bootloader,
either specifying the PARTUUID= of the partition that contains the Endless
image.

The endless.image.path parameter provides the path to the image file on
that filesystem.

A new generator handles these parameters and hooks up the final block
device setup to the normal systemd initramfs fsck/mount infrastructure.

The block device setup script identifies which disk extents are occupied
by the image file and creates a linear device-mapper device that
corresponds. This is easier and much better performing than going through
exfat-fuse.

The repartitioning code now supports working with the resultant
device-mapper setup. We no longer get size and start info from sysfs,
because the sysfs paths to access dm info are a bit harder to deduce,
and the 'start' attribute is not present. We now use blockdev to get
the size, and we read the partition start from the sfdisk dump.

All that should cover the case for the regular booting of an Endless
image stored on a windows filesystem.

The endless.live_boot parameter implementation additionally tends to a
special case for the combined USB live+installer disk. In this case,
the image file used for live boot needs to be left untouched and pristine
so that the installer can work with it too. When this parameter is
specified, all the block devices are created in read-only mode, no
filesystem resizing is attempted, the OS updater is disabled, and
overlayfs is used for (throw-away) writable filesystem backing.

The overlay setup had to be split in 2. Most of them need to be created
quite late during real-root boot to avoid fighting with ostree-remount,
but /etc needs to be done before we switch root.

https://phabricator.endlessm.com/T12481