### PR TITLE
Provide read-only access to the filesystem hosting endless.img

### DIFF
--- a/10-allow-mounting-endless-image-device.rules
+++ b/10-allow-mounting-endless-image-device.rules
@@ -1,0 +1,7 @@
+polkit.addRule(function(action, subject) {
+  if (action.id == "org.freedesktop.udisks2.filesystem-mount-system" &&
+      action.lookup("device") == "/dev/mapper/endless-image-device" &&
+      subject.local && subject.active) {
+    return polkit.Result.YES;
+  }
+});

--- a/Makefile.am
+++ b/Makefile.am
@@ -32,6 +32,11 @@ uninstall-hook:
 udevrulesdir = $(udevdir)/rules.d
 dist_udevrules_DATA = 50-meson-vdec.rules
 
+polkitrulesdir = $(datadir)/polkit-1/rules.d
+dist_polkitrules_DATA = \
+	10-allow-mounting-endless-image-device.rules \
+	$(NULL)
+
 dist_sbin_SCRIPTS = \
 	eos-firstboot \
 	eos-extra-resize \

--- a/Makefile.am
+++ b/Makefile.am
@@ -12,6 +12,7 @@ dist_systemdunit_DATA = \
 	eos-extra-resize.service \
 	eos-enable-extra-upgrade.service \
 	eos-enable-zram.service \
+	eos-image-boot-dm-setup.service \
 	eos-live-boot-overlayfs-setup.service \
 	$(NULL)
 
@@ -36,6 +37,7 @@ dist_sbin_SCRIPTS = \
 	eos-extra-resize \
 	eos-enable-extra-upgrade \
 	eos-enable-zram \
+	eos-image-boot-dm-setup \
 	eos-live-boot-overlayfs-setup \
 	eos-repartition-mbr \
 	$(NULL)

--- a/dracut/image-boot/eos-image-boot-generator
+++ b/dracut/image-boot/eos-image-boot-generator
@@ -16,12 +16,20 @@ image_path=$(getarg endless.image.path=)
 
 [ -z "${image_device}" -o -z "${image_path}" ] && exit 0
 
+# Make sure runtime udev rules dir exists
+mkdir -p /run/udev/rules.d
+
 case "${image_device}" in
 PARTUUID=*)
+  echo "SUBSYSTEM==\"block\", ENV{ID_PART_ENTRY_UUID}==\"${image_device#PARTUUID=}\", ENV{DM_NAME}!=\"endless-image-device\", ENV{UDISKS_IGNORE}=\"1\"" > /run/udev/rules.d/79-endless-image-device.rules
   image_device=/dev/disk/by-partuuid/${image_device#PARTUUID=}
   ;;
 UUID=*)
+  echo "SUBSYSTEM==\"block\", ENV{ID_FS_UUID}==\"${image_device#UUID=}\", ENV{DM_NAME}!=\"endless-image-device\", ENV{UDISKS_IGNORE}=\"1\"" > /run/udev/rules.d/79-endless-image-device.rules
   image_device=/dev/disk/by-uuid/${image_device#UUID=}
+  ;;
+*)
+  echo "SUBSYSTEM==\"block\", ENV{DEVNAME}==\"${image_device}\", ENV{UDISKS_IGNORE}=\"1\"" > /run/udev/rules.d/79-endless-image-device.rules
   ;;
 esac
 

--- a/eos-image-boot-dm-setup
+++ b/eos-image-boot-dm-setup
@@ -1,0 +1,96 @@
+#!/bin/bash
+# Copyright (C) 2016 Endless Mobile, Inc.
+# Licensed under the GPLv2
+#
+# When booting from an image file hosted on a filesystem, this program maps the
+# host filesystem to a dm-device with a hole where the image file lives.
+
+for i in $(</proc/cmdline); do
+  case $i in
+  endless.image.device=*)
+    host_device=${i//endless.image.device=}
+    ;;
+  endless.image.path=*)
+    image_path=${i//endless.image.path=}
+    ;;
+  esac
+done
+
+dm_roflag="--readonly"
+
+[ -z "${host_device}" -o -z "${image_path}" ] && exit 1
+
+case "${host_device}" in
+PARTUUID=*)
+  host_device=/dev/disk/by-partuuid/${host_device#PARTUUID=}
+  ;;
+UUID=*)
+  host_device=/dev/disk/by-uuid/${host_device#UUID=}
+  ;;
+esac
+
+host_device_size=$(blockdev --getsz ${host_device})
+if [ $? != 0 ]; then
+  echo "Failed to read ${host_device} size"
+  exit 1
+fi
+
+fstype=$(blkid -o value -s TYPE "${host_device}")
+if [ $? != 0 ]; then
+  echo "Failed to detect filesystem type on ${host_device}"
+  exit 1
+fi
+
+case "${fstype}" in
+exfat)
+  extents=$(dumpexfat -f "${image_path}" "${host_device}")
+  ;;
+ntfs)
+  extents=$(ntfsextents "${host_device}" "${image_path}")
+  ;;
+*)
+  echo "Unsupported filesystem ${fstype} on ${host_device}"
+  exit 1
+esac
+
+if [ $? != 0 ]; then
+  echo "Failed to lookup ${image_path} on ${host_device} (${fstype})"
+  exit 1
+fi
+
+# Sort the file extents so we create the holes in the correct places
+extents=$(echo "$extents" | sort -n)
+
+# Cleanup the device mapper table file from previous runs
+rm -f /tmp/dmtable
+
+i=0
+while read extent_i extent_size; do
+  [ -z "${extent_i}" -o -z "${extent_size}" ] && continue
+
+  if [ $((extent_size % 512)) != 0 ]; then
+    echo "Extent size $extent_size is not sector-aligned"
+    exit 1
+  fi
+
+  extent_size=$((extent_size / 512))
+  extent_i=$((extent_i / 512))
+
+  if [ ${i} -lt ${extent_i} ]; then
+    echo "${i} $((extent_i - i)) linear ${host_device} ${i}" >> /tmp/dmtable
+    echo "${extent_i} ${extent_size} error" >> /tmp/dmtable
+    i=$((extent_i + extent_size))
+  fi
+done <<< "$(echo "$extents")"
+
+if [ ${i} -lt ${host_device_size} ]; then
+  echo "${i} $((host_device_size - i)) linear ${host_device} ${i}" >> /tmp/dmtable
+fi
+
+dmsetup create endless-image-device $dm_roflag < /tmp/dmtable
+if [ $? != 0 ]; then
+  echo "Failed to set up a device map for ${host_device}"
+  exit 1
+fi
+
+exit 0

--- a/eos-image-boot-dm-setup.service
+++ b/eos-image-boot-dm-setup.service
@@ -1,0 +1,13 @@
+[Unit]
+Description=Endless image boot device mapper setup
+DefaultDependencies=no
+After=ostree-remount.service
+Before=local-fs.target
+ConditionKernelCommandLine=endless.image.device
+
+[Service]
+Type=oneshot
+ExecStart=/usr/sbin/eos-image-boot-dm-setup
+
+[Install]
+WantedBy=local-fs.target


### PR DESCRIPTION
We are mapping the partition passed in the `endless.image.device=` kernel command line argument to a device mapper device called `host`, and installing the necessary polkit rules to allow for regular users to mount it through the file manager (so a dual-boot user can access its files on the windows partition).

When setting up the dm device, we're mapping the blocks where `endless.img` lives to `error`, so any I/O attempt on them through this dm device fails, adding an additional layer of protection to `endless.img`. This implies that the flasher tool will have to read from dm device which maps `endless.img` and not from the `endless.img` file. Reading from the dm device also should have a better performance than reading from the `endless.img` file, since we will not have to go through FUSE.

Additionally, this also hides the partition passed through `endless.image.device=` from the file manager, since it can't be mounted anyway because it is in use by the device mapper.

https://phabricator.endlessm.com/T13135