### PR TITLE
Handle /var/endless-extra on upgrade correctly

### DIFF
--- a/eos-enable-extra-upgrade
+++ b/eos-enable-extra-upgrade
@@ -84,6 +84,3 @@ ln -sf "$mount_unit_path" "$wants_link"
 
 # Reload systemd so that the new unit is seen to be enabled
 systemctl daemon-reload
-
-# Start the unit now so that the SD card (hopefully) gets mounted
-systemctl start "$mount_unit"

--- a/eos-enable-extra-upgrade.service
+++ b/eos-enable-extra-upgrade.service
@@ -3,11 +3,20 @@
 
 [Unit]
 Description=Enable Endless extra storage mount on upgrade
-# Need DefaultDependencies=no so sysinit.target is not required
+# Need DefaultDependencies=no so local-fs.target is not required
 DefaultDependencies=no
+# Standard local-fs conflicts and ordering
 Conflicts=shutdown.target
-After=local-fs.target
-Before=sysinit.target shutdown.target systemd-update-done.service
+Before=local-fs.target shutdown.target
+# Need normal mounts done for /usr and /var from ostree
+After=ostree-remount.service
+# Ensure /var/eos-extra-resize has been created
+After=eos-extra-resize.service
+# Run before systemd analyzes the /var/endless-extra mount unit
+Before=var-endless\x2dextra.mount
+
+# Only run on updates
+Before=systemd-update-done.service
 ConditionNeedsUpdate=/etc
 
 # Only run on units that have resized the extra filesystem
@@ -20,4 +29,4 @@ StandardOutput=journal+console
 ExecStart=/usr/sbin/eos-enable-extra-upgrade
 
 [Install]
-WantedBy=basic.target
+WantedBy=local-fs.target

--- a/eos-enable-zram.service
+++ b/eos-enable-zram.service
@@ -1,6 +1,6 @@
 [Unit]
 Description=swap with zram
-Before=swap.target
+Before=multi-user.target
 ConditionArchitecture=arm
 
 [Service]
@@ -11,4 +11,4 @@ ExecStart=/usr/sbin/eos-enable-zram 200
 ExecStop=/usr/sbin/eos-enable-zram 0
 
 [Install]
-WantedBy=swap.target
+WantedBy=multi-user.target


### PR DESCRIPTION
Backport fixes for handling the /var/endless-extra mount after upgrading from a system where /endless was an overlayfs mount.

https://phabricator.endlessm.com/T12747