### PR TITLE
Allow mounting endless-image-device rw

### DIFF
--- a/eos-image-boot-dm-setup
+++ b/eos-image-boot-dm-setup
@@ -16,8 +16,6 @@ for i in $(</proc/cmdline); do
   esac
 done
 
-dm_roflag="--readonly"
-
 [ -z "${host_device}" -o -z "${image_path}" ] && exit 1
 
 case "${host_device}" in
@@ -87,7 +85,7 @@ if [ ${i} -lt ${host_device_size} ]; then
   echo "${i} $((host_device_size - i)) linear ${host_device} ${i}" >> /tmp/dmtable
 fi
 
-dmsetup create endless-image-device $dm_roflag < /tmp/dmtable
+dmsetup create endless-image-device < /tmp/dmtable
 if [ $? != 0 ]; then
   echo "Failed to set up a device map for ${host_device}"
   exit 1


### PR DESCRIPTION
This should be safe now we have logic to guard the image file in
exfat-fuse and ntfs-3g. In the dual-boot case, this allows users to
delete files from their Windows drive to their heart's content! In the
combined USB case, this allows us to (potentially) save a debug log to
the image device.

https://phabricator.endlessm.com/T13136

