### PR TITLE
image-boot-generator: make endless-image world-readable

### DIFF
--- a/dracut/image-boot/eos-image-boot-generator
+++ b/dracut/image-boot/eos-image-boot-generator
@@ -51,6 +51,8 @@ EOF
 
 if getargbool 0 endless.live_boot; then
   rwflag=ro
+  # Allow live user to read mapped image directly (in particular, when reflashing)
+  echo 'SUBSYSTEM=="block", ENV{DM_NAME}=="endless-image", MODE="0664"' > /run/udev/rules.d/79-endless-image.rules
 else
   rwflag=rw
 fi


### PR DESCRIPTION
When booted from a pristine image (on USB), one of the options presented
to the user is to run eos-installer to overwrite the system's hard drive
with the booted pristine image.

In eos-installer, we cannot read /endless/endless.img from the DM device
mapped over the host partition, because its sectors are blocked out with
'error'. Even if we could, we expect reading the mapped 'endless-image'
device to be substantially faster than going via FUSE.

By default, the mapped device will be owned by root:disk with
permissions 0660, so eos-installer (running as gnome-initial-setup or
the live user) cannot read it. It cannot be opened with UDisks'
OpenForBackup() method, which is documented to not support opening
devices which are in use (it passes O_EXCL to open(2) to implement
this). If we were to add a parameter to allow opening in-use devices
with this method, we'd still have to refactor eos-installer to have two
code paths for reading image files: one opening the file directly, and
one going via UDisks.

It seems that the most straightforward way to arrange for the device to
be world-readable; and I can't think of a situation where a user having
access to the *pristine*, booted OS image on an image-booted system is a
real security problem. On dual-boot systems, this is not the case, so we
only do this in the endless.live_boot case.

https://phabricator.endlessm.com/T12548