### PR TITLE
T13741: live boot:  don't overlay /sysroot in its entirety

### DIFF
--- a/eos-live-boot-overlayfs-setup
+++ b/eos-live-boot-overlayfs-setup
@@ -3,7 +3,7 @@
 # Mount overlays over any directory that might be written to
 # Note that /etc was handled in the initramfs since it must be done early.
 # The rest of these should be done later, to avoid fighting with ostree-remount
-overlay_dirs="bin boot endless home lib opt ostree root sbin srv sysroot var"
+overlay_dirs="bin boot endless home lib opt ostree root sbin srv sysroot/flatpak sysroot/home sysroot/ostree var"
 for dir in $overlay_dirs; do
     [ -d /$dir ] || continue
     # If the directory is a symlink, assume it's pointing to a location


### PR DESCRIPTION
If 'endless.live_boot' is on the command line, we pass '--readonly' to
dmsetup when mapping endless-image, and we mount it on /sysroot with the
'ro' flag. So, we don't need to overlay it with a tmpfs to protect it
from modification.

We need to mask:

* /sysroot/flatpak
* /sysroot/home (symlinked from /var/home and /home)
* /sysroot/ostree

as all these potentially need to be written to.

A side-effect of leaving /sysroot untouched is that we can successfully
read xattrs from it -- specifically, the eos-image-version attribute,
used by eos-phone-home (and other applications).

https://phabricator.endlessm.com/T13741