### PR TITLE
live-boot: enable user xattrs on /run

### DIFF
--- a/eos-live-boot-overlayfs-setup
+++ b/eos-live-boot-overlayfs-setup
@@ -1,5 +1,10 @@
 #!/bin/bash
 
+# Allow xattrs in the user namespace on /run, and by extension in the ostree
+# repo, where they are used to record permissions when run as an unprivileged
+# user.
+mount -o remount,user_xattr /run
+
 # Mount overlays over any directory that might be written to
 # Note that /etc was handled in the initramfs since it must be done early.
 # The rest of these should be done later, to avoid fighting with ostree-remount


### PR DESCRIPTION
This depends on a patch in our kernel to add the user_xattr flag in the
first place.

https://phabricator.endlessm.com/T13817