### PR TITLE
eos-repartition-mbr: mark the root partition as bootable

### DIFF
--- a/eos-repartition-mbr
+++ b/eos-repartition-mbr
@@ -128,8 +128,9 @@ parts=$(echo "$parts" | sed -e "s/${root_disk_dev}[^: ]\+//")
 # GPT -> DOS
 parts=$(echo "$parts" | sed -e "s/label: gpt/label: dos/")
 
-# Set MBR partition type
-parts=$(echo "$parts" | sed -e "s/, type=$dps_root_guid/, type=83/")
+# Set MBR partition type and mark as bootable (not strictly true, but our MBR
+# does not care - some BIOSes don't consider a drive to be bootable without it)
+parts=$(echo "$parts" | sed -e "s/, type=$dps_root_guid/, type=83, bootable/")
 # Remove partition UUIDs and GPT attributes
 parts=$(echo "$parts" | sed -e "s/, \(uuid\|attrs\)=[^\s,]\+//g")
 


### PR DESCRIPTION
The idea behind T12365 is that there are some systems which will not proceed to boot a hard drive unless they have an DOS partition table with one partition marked as bootable. T12793 does the hard work of converting the GPT partition table to a DOS partition table.

However, unfortunately we don't set any of our nice new DOS partitions as bootable... meaning the affected systems that this work was aimed to support can still, in fact, not boot our OS. Oops.

https://phabricator.endlessm.com/T14243