### PR TITLE
repartition: cope with blkid returning an empty string

### DIFF
--- a/dracut/repartition/endless-repartition.sh
+++ b/dracut/repartition/endless-repartition.sh
@@ -89,6 +89,10 @@ if [ -z "${root_disk}" ]; then
 fi
 
 pt_label=$(blkid -o value -s PTTYPE $root_disk)
+if [ -z "$pt_label" ]; then
+  echo "repartition: blkid -o value -s PTTYPE '$root_disk' failed"
+  exit 0
+fi
 
 # Check for our magic "this is Endless" marker
 if [ "$pt_label" == "dos" ]; then


### PR DESCRIPTION
I noticed the following in a log from Mures working on ISO booting:

    endless-repartition[229]: /bin/endless-repartition: 94: [: unexpected operator
    endless-repartition[229]: sfdisk: cannot open /dev/mapper/endless-image: No such file or directory
    endless-repartition[229]: repartition: marker not found

If $pt_label is empty, `[ "$pt_label" == "dos" ]` causes `[` to fail
with the above error message. Let's fail explicitly in that case, rather
than falling through to an `sfdisk` incantation that will also probably
fail.