### PR TITLE
repartition: Add support for NVMe block devices

### DIFF
--- a/dracut/repartition/endless-repartition.sh
+++ b/dracut/repartition/endless-repartition.sh
@@ -59,19 +59,20 @@ get_last_char() {
 }
 
 # We have to work with a variety of setups here:
-# - Either SCSI or MMC block devices with different naming conventions
+# - SCSI/MMC/NVMe block devices with different naming conventions
 # - A different partition numbering scheme as not all configurations have
 #   a ESP and a BIOS boot partition.
 partno=$(get_last_char ${root_part})
+
 swap_partno=$((partno + 1))
 case ${root_part} in
-  /dev/mmcblk?p?)
-    root_disk=${root_part%p?}
-    swap_part=${root_disk}p${swap_partno}
-    ;;
   /dev/sd??)
     root_disk=${root_part%?}
     swap_part=${root_disk}${swap_partno}
+    ;;
+  /dev/*p[0-9])
+    root_disk=${root_part%p?}
+    swap_part=${root_disk}p${swap_partno}
     ;;
 esac
 

--- a/eos-extra-resize
+++ b/eos-extra-resize
@@ -19,7 +19,7 @@ if [ -z $extra_part ]; then
 fi
 
 case ${extra_part} in
-    /dev/mmcblk?p1)
+    /dev/*p1)
         extra_disk=${extra_part%p1}
         ;;
     /dev/sd?1)


### PR DESCRIPTION
Accept all devices ending with "p" then a number.
This will cover existing MMC cases (e.g. mmcblk1p3) and also
NVMe (e.g. nvme0n1p3).

https://phabricator.endlessm.com/T14393