### PR TITLE
reparition: Don't leave stale boot entries behind

### DIFF
--- a/dracut/repartition/module-setup.sh
+++ b/dracut/repartition/module-setup.sh
@@ -16,6 +16,9 @@ install() {
   dracut_install mkswap
   dracut_install sed
   dracut_install tune2fs
+  dracut_install efibootmgr
+  dracut_install grep
+  dracut_install cut
   dracut_install -o amlogic-fix-spl-checksum
   inst_script "$moddir/endless-repartition.sh" /bin/endless-repartition
   inst_simple "$moddir/endless-repartition.service" \


### PR DESCRIPTION
Changing the ESP's UUID breaks the Endless UEFI boot entry, since it
uses it as part of the loader path. To avoid stale boot entries to
accumulate on the machine, lets remove the Endless boot entry pointing
to the original ESP's UUID.

We could create a new boot entry here, but lets leave this job to
fallback.efi, so we do not need to keep the bootloader's path in sync.

https://phabricator.endlessm.com/T14430