### PR TITLE
Provide service to fix broken flatpak desktop files

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -14,6 +14,7 @@ dist_systemdunit_DATA = \
 	eos-enable-zram.service \
 	eos-image-boot-dm-setup.service \
 	eos-live-boot-overlayfs-setup.service \
+	eos-fix-flatpak-branches.service \
 	$(NULL)
 
 # Unfortunately, the escaped \x2d is handled poorly, so we distribute
@@ -45,4 +46,5 @@ dist_sbin_SCRIPTS = \
 	eos-image-boot-dm-setup \
 	eos-live-boot-overlayfs-setup \
 	eos-repartition-mbr \
+	eos-fix-flatpak-branches \
 	$(NULL)

--- a/eos-fix-flatpak-branches
+++ b/eos-fix-flatpak-branches
@@ -1,0 +1,37 @@
+#!/bin/bash -e
+
+# We shipped apps in 3.0.10 and 3.0.11 that have the wrong branch in the
+# desktop file. Attempt to fix them.
+
+if [ -d /var/endless-extra/flatpak ]; then
+    flatpak_dir=/var/endless-extra/flatpak
+else
+    flatpak_dir=/var/lib/flatpak
+fi
+
+for app_dir in "$flatpak_dir"/app/*; do
+    [ -d "$app_dir" ] || continue
+
+    # Figure out what the installed branch is. The current symlink looks
+    # like $arch/$branch.
+    current=$(readlink "$app_dir"/current)
+    current_branch=${current##*/}
+
+    # This only affects eos3 apps
+    [ "$current_branch" = eos3 ] || continue
+
+    # Change the --branch=$branch argument in each desktop file to use
+    # the current branch.
+    desktop_dir="$app_dir"/current/active/export/share/applications
+    for desktop in "$desktop_dir"/*.desktop; do
+        [ -f "$desktop" ] || continue
+
+        exec_line=$(grep '^Exec' "$desktop" || true)
+        [ -n "$exec_line" ] || continue
+        echo "Updating $desktop to use --branch=$current_branch"
+        echo "Before: $exec_line"
+        sed -ri "/^Exec/s/(--branch=)[^[:space:]]+/\1${current_branch}/" "$desktop"
+        exec_line=$(grep '^Exec' "$desktop")
+        echo "After: $exec_line"
+    done
+done

--- a/eos-fix-flatpak-branches.service
+++ b/eos-fix-flatpak-branches.service
@@ -1,0 +1,19 @@
+[Unit]
+Description=Fix branch references in flatpak desktop files
+# Only run on updates. Need DefaultDependencies=no so this can run
+# before sysinit.target and not create a circular dependency with
+# systemd-update-done.service.
+DefaultDependencies=no
+Conflicts=shutdown.target
+Wants=local-fs.target
+After=local-fs.target
+Before=multi-user.target systemd-update-done.service
+ConditionNeedsUpdate=/var
+
+[Service]
+Type=oneshot
+RemainAfterExit=true
+ExecStart=/usr/sbin/eos-fix-flatpak-branches
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
For 3.0.10 and 3.0.11, the image builder was changed so that it
installed from the eos3.0 refs instead of the eos3 refs so that there
wasn't interference from eos3.1. To make it look like eos3 apps were
installed, the app checkout directories were changed to look that way.
Unfortunately, the branch is also embedded in the desktop file when
flatpak exports it, and this was not updated.

Provide a boot service that tries to find and fix these desktop files.
This will run only on upgrade.

https://phabricator.endlessm.com/T15005