### PR TITLE
extra.mount: Fix use of deprecated systemd unit file key

### DIFF
--- a/var-endless_x2dextra.mount
+++ b/var-endless_x2dextra.mount
@@ -3,7 +3,7 @@ After=ostree-remount.service
 After=eos-extra-resize.service
 Wants=eos-extra-resize.service
 Before=local-fs.target
-RequiresOverridable=systemd-fsck@dev-disk-by\x2dlabel-extra.service
+Requires=systemd-fsck@dev-disk-by\x2dlabel-extra.service
 After=systemd-fsck@dev-disk-by\x2dlabel-extra.service
 
 [Mount]


### PR DESCRIPTION
RequiresOverridable= has been replaced by Requires=, which has basically
equivalent functionality unless a user starts the unit manually, which
we don’t expect for this mount unit.

See upstream systemd commit f32b43bda454a70ae23d6802605d41b26dc24ce2.

Signed-off-by: Philip Withnall <withnall@endlessm.com>

https://phabricator.endlessm.com/T15452