### PR TITLE
Make sure the title is set for GNOME flatpak repositories

### DIFF
--- a/eos-add-flatpak-gnome-repos
+++ b/eos-add-flatpak-gnome-repos
@@ -47,4 +47,9 @@ EOF
 flatpak remote-add --if-not-exists --from gnome ${TMPDIR}/gnome.flatpakrepo
 flatpak remote-add --if-not-exists --from gnome-apps ${TMPDIR}/gnome-apps.flatpakrepo
 
+# Make sure the title is set as well, as a fix for images built
+# with the repos already configured without titles (EOS <3.1.2)
+flatpak remote-modify --title="Gnome Stable Runtimes" gnome
+flatpak remote-modify --title="Gnome Stable Applications" gnome-apps
+
 exit 0


### PR DESCRIPTION
This is a temporary fix to set a title for those repos in images that
already included configured, but failed to specify the title at the
time of building it (previous to eos 3.1.2).

https://phabricator.endlessm.com/T15580