### PR TITLE
Don't mask eos-updater.timer

### DIFF
--- a/eos-live-boot-overlayfs-setup
+++ b/eos-live-boot-overlayfs-setup
@@ -59,7 +59,3 @@ for dir in $overlay_dirs; do
         rw,upperdir=/run/eos-live/$dir,lowerdir=/$dir,workdir=/run/eos-live/$dir-workdir \
         eos-live-$dir /$dir
 done
-
-# Disable the updater for this boot
-systemctl stop eos-updater.timer
-systemctl mask --runtime eos-updater.timer


### PR DESCRIPTION
This timer was renamed, and so the mask no longer applies. Instead,
we'll add an endless.live_boot condition directly to the timer.

https://phabricator.endlessm.com/T15977