### PR TITLE
dracut: Create customization module

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -31,5 +31,6 @@ AC_CONFIG_FILES([
 	Makefile
 	dracut/Makefile
 	dracut/image-boot/Makefile
-	dracut/repartition/Makefile])
+	dracut/repartition/Makefile
+	dracut/customization/Makefile])
 AC_OUTPUT

--- a/dracut/Makefile.am
+++ b/dracut/Makefile.am
@@ -1,4 +1,4 @@
-SUBDIRS = repartition image-boot
+SUBDIRS = repartition image-boot customization
 
 dracutconfdir = $(sysconfdir)/dracut.conf.d
 dist_dracutconf_DATA = endless.conf

--- a/dracut/customization/Makefile.am
+++ b/dracut/customization/Makefile.am
@@ -1,0 +1,4 @@
+dracutmoddir = $(prefix)/lib/dracut/modules.d/50eos-customization
+dist_dracutmod_SCRIPTS = module-setup.sh \
+			 eos-install-custom-boot-splash
+dist_dracutmod_DATA = eos-install-custom-boot-splash.service

--- a/dracut/customization/eos-install-custom-boot-splash
+++ b/dracut/customization/eos-install-custom-boot-splash
@@ -1,0 +1,32 @@
+#!/bin/sh
+
+CUSTOM_SPLASH_DIR="/eos-customization/plymouth"
+CUSTOM_SPLASH_CONFIG="${CUSTOM_SPLASH_DIR}/plymouthd.defaults"
+PLYMOUTH_RUNTIME_DIR="/run/plymouth"
+
+if [ ! -d ${CUSTOM_SPLASH_DIR} ] ; then
+	echo "${CUSTOM_SPLASH_DIR} not found" >&2
+	exit 1
+fi
+
+if [ ! -f ${CUSTOM_SPLASH_CONFIG} ] ; then
+	echo "${CUSTOM_SPLASH_CONFIG} not found" >&2
+	exit 1
+fi
+
+theme_name="`sed -n 's/Theme=\(.*\)/\1/p' ${CUSTOM_SPLASH_CONFIG}`"
+if [ -z ${theme_name} ]; then
+	echo "Theme entry missing from ${CUSTOM_SPLASH_CONFIG}" >&2
+	exit 1
+fi
+
+if [ ! -d ${CUSTOM_SPLASH_DIR}/themes/${theme_name} ] ; then
+	echo "${CUSTOM_SPLASH_DIR}/themes/${theme_name} not found" >&2
+	exit 1
+fi
+
+mkdir -p ${PLYMOUTH_RUNTIME_DIR}
+cp ${CUSTOM_SPLASH_CONFIG} ${PLYMOUTH_RUNTIME_DIR}
+cp -r ${CUSTOM_SPLASH_DIR}/themes ${PLYMOUTH_RUNTIME_DIR}
+sed -i "s:ImageDir=.*:ImageDir=${PLYMOUTH_RUNTIME_DIR}/themes/${theme_name}:" \
+	${PLYMOUTH_RUNTIME_DIR}/themes/${theme_name}/${theme_name}.plymouth

--- a/dracut/customization/eos-install-custom-boot-splash.service
+++ b/dracut/customization/eos-install-custom-boot-splash.service
@@ -1,0 +1,14 @@
+[Unit]
+Description=Install custom splash theme to runtime dir
+DefaultDependencies=no
+ConditionKernelCommandLine=splash
+ConditionPathExists=/etc/initrd-release
+ConditionDirectoryNotEmpty=/eos-customization/plymouth
+Before=plymouth-start.service
+
+[Service]
+Type=oneshot
+ExecStart=/bin/eos-install-custom-boot-splash
+StandardInput=null
+StandardOutput=syslog
+StandardError=syslog+console

--- a/dracut/customization/module-setup.sh
+++ b/dracut/customization/module-setup.sh
@@ -1,0 +1,21 @@
+# Copyright (C) 2017 Endless Mobile, Inc.
+# Licensed under the GPLv2
+
+check() {
+  return 0
+}
+
+depends() {
+  echo systemd
+}
+
+install() {
+  dracut_install sed
+  inst_script "$moddir/eos-install-custom-boot-splash" \
+    /bin/eos-install-custom-boot-splash
+  inst_simple "$moddir/eos-install-custom-boot-splash.service" \
+    "$systemdsystemunitdir/eos-install-custom-boot-splash.service"
+  mkdir -p "${initdir}/$systemdsystemunitdir/plymouth-start.service.wants"
+  ln_r "$systemdsystemunitdir/eos-install-custom-boot-splash.service" \
+    "$systemdsystemunitdir/plymouth-start.service.wants/eos-install-custom-boot-splash.service"
+}

--- a/dracut/endless.conf
+++ b/dracut/endless.conf
@@ -1,3 +1,3 @@
-dracutmodules="dracut-systemd systemd-initrd dash drm eos-repartition eos-image-boot plymouth kernel-modules resume ostree systemd base fs-lib"
+dracutmodules="dracut-systemd systemd-initrd dash drm eos-repartition eos-image-boot plymouth kernel-modules resume ostree systemd base fs-lib eos-customization"
 fscks="fsck fsck.ext4"
 filesystems="ext4 isofs"


### PR DESCRIPTION
Mechanism to ship image-specific customizations in the initramfs. For
now provides boot splash animation customization support.

https://phabricator.endlessm.com/T15989