### PR TITLE
Allow coexistance with basic data partition at end of disk

### DIFF
--- a/dracut/repartition/endless-repartition.sh
+++ b/dracut/repartition/endless-repartition.sh
@@ -120,18 +120,21 @@ if [ "$pt_label" = "dos" ]; then
   parts=$(echo "$parts" | sed -e '$d')
 fi
 
-# If we detect a recovery partition at the end of the disk, we'll be careful
-# not to destroy it.
+# If we detect a data or recovery partition at the end of the disk, we'll be
+# careful not to destroy it.
 lastparttype=$(echo "$parts" | sed -n -e '$ s/.*type=\([A-F0-9-]\+\).*/\1/p')
-if [ "$lastparttype" = "BFBFAFE7-A34F-448A-9A5B-6213EB736C22" ]; then
-  # We'll use the free space up to where this partition starts
-  preserve_start=$(echo "$parts" | sed -n -e '$ s/.*start=[ ]*\([^,]*\).*/\1/p')
+case ${lastparttype} in
+  BFBFAFE7-A34F-448A-9A5B-6213EB736C22)
+  EBD0A0A2-B9E5-4433-87C0-68B6B72699C7)
+    # We'll use the free space up to where this partition starts
+    preserve_start=$(echo "$parts" | sed -n -e '$ s/.*start=[ ]*\([^,]*\).*/\1/p')
 
-  # Save the partition entry to be restored later, and delete it from the
-  # list for now, to simplify the logic that follows.
-  preserve_partition=$(echo "$parts" | sed -n -e '$ s/[^:]*:\(.*\)$/\1/p')
-  parts=$(echo "$parts" | sed '$d')
-fi
+    # Save the partition entry to be restored later, and delete it from the
+    # list for now, to simplify the logic that follows.
+    preserve_partition=$(echo "$parts" | sed -n -e '$ s/[^:]*:\(.*\)$/\1/p')
+    parts=$(echo "$parts" | sed '$d')
+    ;;
+esac
 
 # check the last partition on the disk
 lastpartno=$(echo "$parts" | sed -n -e '$ s/[^:]*\([0-9]\) :.*$/\1/p')


### PR DESCRIPTION
Similarly to the recovery partition, if we detect a basic data partition
we'll only occupy the space that leads up to it, and leave that partition
intact.

https://phabricator.endlessm.com/T16442