### PR TITLE
repartition: don't format any trailing partition as swap

### DIFF
--- a/dracut/repartition/endless-repartition.sh
+++ b/dracut/repartition/endless-repartition.sh
@@ -183,6 +183,8 @@ if [ $added_space -gt 209715200 ]; then
     # might as well bump up root partition size too, instead of leaving a gap
     new_size=$(( new_size + 2048 - residue ))
   fi
+else
+  swap_part=
 fi
 
 # remove the last-lba line so that we fill the disk


### PR DESCRIPTION
We try to preserve a single trailing partition of type Basic Data
or OEM Recovery on the disk. However, previously, if there was not
enough space to create a swap partition between the root partition and
the preserved partition, we would format the trailing partition as swap.
The logic was simply: if a partition numbered one greater than the root
partition exists, call mkswap on it.

By explicitly unsetting $swap_part when we are not creating a swap
partition, we avoid this problem: the partition-exists test fails and
mkswap is not called.

https://phabricator.endlessm.com/T16442