### PR TITLE
Add eos-fix-home-dir-permissions

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -15,6 +15,7 @@ dist_systemdunit_DATA = \
 	eos-firewall-localonly.service \
 	eos-firstboot.service \
 	eos-fix-flatpak-branches.service \
+	eos-fix-home-dir-permissions.service \
 	eos-image-boot-dm-setup.service \
 	eos-live-boot-overlayfs-setup.service \
 	$(NULL)
@@ -61,6 +62,7 @@ dist_sbin_SCRIPTS = \
 	eos-firewall-localonly \
 	eos-firstboot \
 	eos-fix-flatpak-branches \
+	eos-fix-home-dir-permissions \
 	eos-image-boot-dm-setup \
 	eos-live-boot-overlayfs-setup \
 	eos-repartition-mbr \

--- a/debian/rules
+++ b/debian/rules
@@ -14,6 +14,7 @@ override_dh_systemd_enable:
 	    eos-enable-zram.service \
 	    eos-firstboot.service \
 	    eos-fix-flatpak-branches.service \
+	    eos-fix-home-dir-permissions.service \
 	    eos-image-boot-dm-setup.service \
 	    eos-live-boot-overlayfs-setup.service \
 	    $(NULL)

--- a/eos-fix-home-dir-permissions
+++ b/eos-fix-home-dir-permissions
@@ -1,0 +1,28 @@
+#!/bin/bash -e
+
+# Prior to 3.1.6, home directory permissions were created with dir mode 755.
+# This is now fixed, but on upgrade from an earlier version to 3.1.6,
+# let's perform a one-time clean up of any existing home dirs.
+
+stamp_dir=/var/lib/misc
+stamp_file="$stamp_dir"/eos-dir-mode-700
+
+if [ -f "$stamp_file" ]; then
+    echo "Dir mode 700 has already been set for home directories, exiting"
+    exit 0
+fi
+
+for home_dir in /home/*; do
+    [ -d "$home_dir" ] || continue
+
+    perm=$(stat -c %a "$home_dir")
+
+    if [ "$perm" = "755" ]; then
+        echo "Changing $home_dir dir mode from 755 to 700"
+        chmod 700 "$home_dir"
+    fi
+done
+
+# Create the stamp file to avoid ever running this again
+mkdir -p "$stamp_dir"
+touch "$stamp_file"

--- a/eos-fix-home-dir-permissions.service
+++ b/eos-fix-home-dir-permissions.service
@@ -1,0 +1,19 @@
+# Clean up any home directories which were created with
+# default permissions 755 rather than 700
+
+[Unit]
+Description=Fix existing home directory permissions from 755 to 700
+
+# Only run if the home dir permissions have not yet been cleaned up.
+# The default dir mode was changed for 3.1.6,
+# and we only want to perform this cleanup once, in case
+# an admin later intentionally changes home dir permissions.
+ConditionPathExists=!/var/lib/misc/eos-dir-mode-700
+
+[Service]
+Type=oneshot
+RemainAfterExit=yes
+ExecStart=/usr/sbin/eos-fix-home-dir-permissions
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
Starting with 3.1.6, we default to dir mode 700 for any
new user home directories, but previously we followed
the debian default of 755.

This service runs once after an upgrade from any version
prior to 3.1.6, to change the dir mode of any existing home
directories from 755 to 700.  Once run, a stamp file is
created to avoid running again, so that any further
tweaks by an admin to directory permissions will not be undone.

https://phabricator.endlessm.com/T16858