### PR TITLE
Only allow admins to mount image host partition

### DIFF
--- a/10-allow-mounting-endless-image-device.rules
+++ b/10-allow-mounting-endless-image-device.rules
@@ -1,7 +1,7 @@
 polkit.addRule(function(action, subject) {
   if (action.id == "org.freedesktop.udisks2.filesystem-mount-system" &&
       action.lookup("device") == "/dev/mapper/endless-image-device" &&
-      subject.local && subject.active) {
+      subject.local && subject.active && subject.isInGroup("sudo")) {
     return polkit.Result.YES;
   }
 });


### PR DESCRIPTION
Previously, a standard user (such as the passwordless `shared` user) could mount the partition hosting the `endless.img` file without any authentication. On a dual-boot system, this is the Windows `C:` drive.  We do not enforce any per-file access controls within the NTFS partition (it's hard to map between Windows and Endless OS users, we don't even try) so this allowed a non-admin user on Endless OS to read and write any file on the Windows drive.

With this change, only administrators will be able to mount the image host partition without authentication. If a standard user tries to mount it, they're asked to authenticate with an administrator's password.

If `alice`, an administrator, mounts the device, and `bob`, a standard user, logs in on VT2, `bob` cannot access the mounted device because it is mounted at `/run/media/alice/$LABEL`. That mount point itself, and all its contents, are world-readable and world-writable, but `/run/media/alice` is only readable by `root` and `alice`.

https://phabricator.endlessm.com/T16890