### PR TITLE
add eos-migrate-image-defaults script & service

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -18,6 +18,7 @@ dist_systemdunit_DATA = \
 	eos-fix-home-dir-permissions.service \
 	eos-image-boot-dm-setup.service \
 	eos-live-boot-overlayfs-setup.service \
+	eos-migrate-image-defaults.service \
 	$(NULL)
 
 # Network Manager dispatcher script for the firewall - scripts which
@@ -65,5 +66,6 @@ dist_sbin_SCRIPTS = \
 	eos-fix-home-dir-permissions \
 	eos-image-boot-dm-setup \
 	eos-live-boot-overlayfs-setup \
+	eos-migrate-image-defaults \
 	eos-repartition-mbr \
 	$(NULL)

--- a/eos-migrate-image-defaults
+++ b/eos-migrate-image-defaults
@@ -1,0 +1,60 @@
+#!/bin/bash -ex
+
+migration_stamp=/var/lib/.eos-migrate-image-defaults
+
+old_path=/var/eos-image-defaults
+new_path=/var/lib/eos-image-defaults
+
+dconf_profile_etc=/etc/dconf/profile/user
+dconf_profile_usr=/usr/share/dconf/profile/user
+
+# create the migration stamp if the old path exists (not a symlink)
+# and the new path does not exist. the process can be safely re-run
+# until it's successful, and will be re-tried until all steps have
+# succeeded and the stamp will be removed at the end.
+if [ -d "${old_path}" -a ! -h "${old_path}" -a ! -e "${new_path}" ]; then
+  touch "${migration_stamp}"
+fi
+
+if [ -f "${migration_stamp}" ]; then
+  # for safety, add the new path to the legacy dconf file during the migration,
+  # in case there is any interruption. this will cause errors due to one path
+  # not existing, but ensure the settings are respected until the migration is
+  # fully completed (eg on next reboot).
+  if [ -f "${dconf_profile_etc}" ] &&
+     ! grep -qs "${new_path}" "${dconf_profile_etc}"; then
+    sed -i "s|^file-db:${old_path}/settings$|file-db:${new_path}/settings\nfile-db:${old_path}/settings|" "${dconf_profile_etc}"
+  fi
+
+  # move the directory if it still needs moving (same conditions as above).
+  if [ -d "${old_path}" -a ! -h "${old_path}" -a ! -e "${new_path}" ]; then
+    mv "${old_path}" "${new_path}"
+  fi
+
+  # now the folder is moved, we can remove the old path from the dconf profile.
+  if [ -f "${dconf_profile_etc}" ]; then
+    sed -i "\|^file-db:${old_path}/settings$|d" "${dconf_profile_etc}"
+
+    # and if it's now the same as the system default one, we can safely delete it.
+    # otherwise there is a local admin customisation we should preserve.
+    if diff "${dconf_profile_etc}" "${dconf_profile_usr}"; then
+      rm -f "${dconf_profile_etc}"
+    fi
+  fi
+
+  # the creation of the compatibility symlink completes the migration
+  ln -sfT "${new_path}" "${old_path}"
+
+  # remove the stamp so that the migration is not attempted again
+  rm -f "${migration_stamp}"
+fi
+
+# the settings db has been mandatory since before 3.0, but upgrades from 2.x
+# won't have it, so the folder may not exist. ensure that it does, and that
+# it contains an empty settings override file.
+if [ ! -f "${new_path}/settings" ]; then
+  mkdir -p "${new_path}"
+  tmpdir=$(mktemp -d)
+  dconf compile "${new_path}/settings" "${tmpdir}"
+  rmdir "${tmpdir}"
+fi

--- a/eos-migrate-image-defaults.service
+++ b/eos-migrate-image-defaults.service
@@ -1,0 +1,12 @@
+[Unit]
+Description=Migrate eos-image-defaults to /var/lib
+ConditionPathExists=|!/var/lib/eos-image-defaults/settings
+ConditionPathExists=|/var/lib/.eos-migrate-image-defaults
+
+[Service]
+Type=oneshot
+RemainAfterExit=true
+ExecStart=/usr/sbin/eos-migrate-image-defaults
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
Simple systemd unit and script to check if /var/eos-image-defaults
is a directory (and not a symlink), move it to /var/lib, and make
a compatibility symlink.

https://phabricator.endlessm.com/T15704