### PR TITLE
image-boot: support squashfs on exFAT

### DIFF
--- a/dracut/image-boot/Makefile.am
+++ b/dracut/image-boot/Makefile.am
@@ -1,9 +1,10 @@
 dracutmoddir = $(prefix)/lib/dracut/modules.d/50eos-image-boot
 dist_dracutmod_SCRIPTS = \
-	module-setup.sh \
-	eos-image-boot-setup \
 	eos-image-boot-generator \
+	eos-image-boot-setup \
 	eos-live-early-overlayfs-setup \
+	eos-map-image-file \
+	module-setup.sh \
 	$(NULL)
 dist_dracutmod_DATA = \
 	eos-image-boot-setup.service \

--- a/dracut/image-boot/Makefile.am
+++ b/dracut/image-boot/Makefile.am
@@ -1,3 +1,11 @@
 dracutmoddir = $(prefix)/lib/dracut/modules.d/50eos-image-boot
-dist_dracutmod_SCRIPTS = module-setup.sh eos-image-boot-setup eos-image-boot-generator eos-live-early-overlayfs-setup
-dist_dracutmod_DATA = eos-image-boot-setup.service eos-live-early-overlayfs-setup.service
+dist_dracutmod_SCRIPTS = \
+	module-setup.sh \
+	eos-image-boot-setup \
+	eos-image-boot-generator \
+	eos-live-early-overlayfs-setup \
+	$(NULL)
+dist_dracutmod_DATA = \
+	eos-image-boot-setup.service \
+	eos-live-early-overlayfs-setup.service \
+	$(NULL)

--- a/dracut/image-boot/eos-image-boot-setup
+++ b/dracut/image-boot/eos-image-boot-setup
@@ -65,6 +65,7 @@ linear_map() {
 # first map that, then setup a loopback device for the uncompressed image
 # within it.
 
+# First, map the outermost image file (uncompressed or squashfs)
 case "${fstype}" in
 exfat | ntfs)
   if ! eos-map-image-file "$host_device" "$image_path" "$target_name$squashfs"
@@ -86,9 +87,15 @@ iso9660)
   fi
 
   # Create a loopback device backing the squashfs
-  if ! squash_device=$(losetup --find --show /cd/${image_path}); then
+  if ! image_device=$(losetup --find --show /cd/${image_path}); then
     echo "losetup failed for /cd/${image_path}"
     exit 1
+  fi
+
+  if [ -n "$squashfs" ]; then
+    squash_device="$image_device"
+  else
+    linear_map "$image_device"
   fi
   ;;
 *)

--- a/dracut/image-boot/eos-image-boot-setup
+++ b/dracut/image-boot/eos-image-boot-setup
@@ -39,14 +39,42 @@ if [ $? != 0 ]; then
   exit 1
 fi
 
+# $squashfs is used both as a suffix for the device-mapper device (if needed),
+# and as a flag indicating that we're dealing with a squashfs.
+case "$image_path" in
+*.squash)  squashfs=-squashfs ;;
+*)         squashfs=          ;;
+esac
+
+linear_map() {
+  # Create a device-mapper linear device corresponding to the given loopback.
+  # If $image_path is uncompressed, and $host_device is NTFS or exFAT,
+  # eos-map-image-file will create this linear device directly and this
+  # function is unused.
+  local device="${1:?}"
+  local size_bytes=$(lsblk --output SIZE --nodeps --bytes --noheadings ${device})
+  if ! echo "0 $((size_bytes / 512 )) linear ${device} 0" \
+    | dmsetup create $target_name $dm_roflag; then
+    echo "Failed to create linear device for ${device}" >&2
+    exit 1
+  fi
+}
+
 # Identify the EOS image extents on the host device, and create a dm-linear
-# block device that maps exactly to that.
+# block device that maps exactly to that. If the image is a squashfs, then
+# first map that, then setup a loopback device for the uncompressed image
+# within it.
 
 case "${fstype}" in
 exfat | ntfs)
-  if ! eos-map-image-file "${host_device}" "${image_path}" $target_name; then
+  if ! eos-map-image-file "$host_device" "$image_path" "$target_name$squashfs"
+  then
     echo "Failed to map ${image_path} on ${host_device}" >&2
     exit 1
+  fi
+
+  if [ -n "$squashfs" ]; then
+    squash_device="/dev/mapper/$target_name$squashfs"
   fi
   ;;
 iso9660)
@@ -62,7 +90,15 @@ iso9660)
     echo "losetup failed for /cd/${image_path}"
     exit 1
   fi
+  ;;
+*)
+  echo "image-boot: unsupported filesystem ${fstype}"
+  exit 1
+esac
 
+# If $image_path is a squashfs, now create a loopback device for the
+# uncompressed image within it
+if [ -n "$squash_device" ]; then
   # Mount the squashfs
   mkdir /squash
   if ! mount ${squash_device} /squash; then
@@ -72,19 +108,8 @@ iso9660)
   
   # Create a loopback device backing the endless image
   host_device=$(losetup --find --show /squash/endless.img)
-
-  # Create a device-mapper linear device corresponding to the loopback
-  size_bytes=$(lsblk --output SIZE --nodeps --bytes --noheadings ${host_device})
-  if ! echo "0 $((size_bytes / 512 )) linear ${host_device} 0" \
-    | dmsetup create $target_name $dm_roflag; then
-    echo "Failed to create linear device for ${host_device}" >&2
-    exit 1
-  fi
-  ;;
-*)
-  echo "image-boot: unsupported filesystem ${fstype}"
-  exit 1
-esac
+  linear_map "$host_device"
+fi
 
 if ! kpartx $kpartx_roflag -a -v /dev/mapper/$target_name; then
   echo "image-boot: failed to probe partitions"

--- a/dracut/image-boot/eos-image-boot-setup
+++ b/dracut/image-boot/eos-image-boot-setup
@@ -6,17 +6,31 @@
 # We identify which disk blocks correspond to the image file, and create
 # a dm-linear block device mapping them.
 
-type getarg >/dev/null 2>&1 || . /lib/dracut-lib.sh
+if [ $# -ge 1 ]; then
+  # For testing
+  if [ "$1" = "--readonly" ]; then
+    shift
+    dm_roflag=--readonly
+    kpartx_roflag=-r
+  fi
 
-host_device=$(cat /var/tmp/endless-image-host)
-image_path=$(getarg endless.image.path)
+  host_device="$1"
+  image_path="$2"
+  target_name="$3"
+else
+  type getarg >/dev/null 2>&1 || . /lib/dracut-lib.sh
 
-udevadm settle
-blockdev --setro ${host_device}
+  host_device=$(cat /var/tmp/endless-image-host)
+  image_path=$(getarg endless.image.path)
+  target_name=endless-image
 
-if getargbool 0 endless.live_boot; then
-  dm_roflag=--readonly
-  kpartx_roflag=-r
+  udevadm settle
+  blockdev --setro ${host_device}
+
+  if getargbool 0 endless.live_boot; then
+    dm_roflag=--readonly
+    kpartx_roflag=-r
+  fi
 fi
 
 fstype=$(lsblk --noheadings -o FSTYPE "${host_device}")
@@ -30,7 +44,7 @@ fi
 
 case "${fstype}" in
 exfat | ntfs)
-  if ! eos-map-image-file "${host_device}" "${image_path}" endless-image; then
+  if ! eos-map-image-file "${host_device}" "${image_path}" $target_name; then
     echo "Failed to map ${image_path} on ${host_device}" >&2
     exit 1
   fi
@@ -62,7 +76,7 @@ iso9660)
   # Create a device-mapper linear device corresponding to the loopback
   size_bytes=$(lsblk --output SIZE --nodeps --bytes --noheadings ${host_device})
   if ! echo "0 $((size_bytes / 512 )) linear ${host_device} 0" \
-    | dmsetup create endless-image $dm_roflag; then
+    | dmsetup create $target_name $dm_roflag; then
     echo "Failed to create linear device for ${host_device}" >&2
     exit 1
   fi
@@ -72,7 +86,7 @@ iso9660)
   exit 1
 esac
 
-if ! kpartx $kpartx_roflag -a -v /dev/mapper/endless-image; then
+if ! kpartx $kpartx_roflag -a -v /dev/mapper/$target_name; then
   echo "image-boot: failed to probe partitions"
   exit 1
 fi

--- a/dracut/image-boot/eos-image-boot-setup
+++ b/dracut/image-boot/eos-image-boot-setup
@@ -1,5 +1,5 @@
 #!/bin/sh
-# Copyright (C) 2016 Endless Mobile, Inc.
+# Copyright (C) 2016-2017 Endless Mobile, Inc.
 # Licensed under the GPLv2
 #
 # Support booting from an image file hosted on a filesystem.
@@ -29,11 +29,11 @@ fi
 # block device that maps exactly to that.
 
 case "${fstype}" in
-exfat)
-  extents=$(dumpexfat -f "${image_path}" "${host_device}")
-  ;;
-ntfs)
-  extents=$(ntfsextents "${host_device}" "${image_path}")
+exfat | ntfs)
+  if ! eos-map-image-file "${host_device}" "${image_path}" endless-image; then
+    echo "Failed to map ${image_path} on ${host_device}" >&2
+    exit 1
+  fi
   ;;
 iso9660)
   # Mount the ISO image
@@ -61,41 +61,16 @@ iso9660)
 
   # Create a device-mapper linear device corresponding to the loopback
   size_bytes=$(lsblk --output SIZE --nodeps --bytes --noheadings ${host_device})
-  extents="0 ${size_bytes}"
+  if ! echo "0 $((size_bytes / 512 )) linear ${host_device} 0" \
+    | dmsetup create endless-image $dm_roflag; then
+    echo "Failed to create linear device for ${host_device}" >&2
+    exit 1
+  fi
   ;;
 *)
   echo "image-boot: unsupported filesystem ${fstype}"
   exit 1
 esac
-
-if [ $? != 0 ]; then
-  echo "image-boot: failed to lookup image on device"
-  exit 1
-fi
-
-offset=0
-echo "$extents" | while read extent_offset extent_size; do
-  [ -z "${extent_offset}" -o -z "${extent_size}" ] && continue
-  # Convert bytes to sectors, rounding up
-  if [ $(( extent_size % 512 )) != 0 ]; then
-    echo "image-boot: extent size $extent_size not sector-aligned" >&2
-    exit 1
-  fi
-  extent_size=$(( extent_size / 512 ))
-  extent_offset=$(( extent_offset / 512 ))
-  echo "${offset} ${extent_size} linear ${host_device} $extent_offset"
-  offset=$((offset + extent_size))
-done > /tmp/dmtable
-
-if [ $? != 0 ]; then
-  exit 1
-fi
-
-dmsetup create endless-image $dm_roflag < /tmp/dmtable
-if [ $? != 0 ]; then
-  echo "image-boot: failed to set up linear mapping"
-  exit 1
-fi
 
 if ! kpartx $kpartx_roflag -a -v /dev/mapper/endless-image; then
   echo "image-boot: failed to probe partitions"

--- a/dracut/image-boot/eos-map-image-file
+++ b/dracut/image-boot/eos-map-image-file
@@ -1,0 +1,77 @@
+#!/bin/sh
+# Copyright (C) 2016-2017 Endless Mobile, Inc.
+# Licensed under the GPLv2
+#
+# Usage:
+#  eos-map-image-file [--readonly] host-device image-path target-device-name
+#
+# Identifies which disk blocks correspond to image-path on host-device, and
+# creates a dm-linear block device at /dev/mapper/target-device-name mapping
+# them. If --readonly is given, the mapped device will be read-only.
+#
+set -e
+
+if [ "$1" = "--readonly" ]; then
+  shift
+  dm_roflag=--readonly
+fi
+
+host_device="${1:?host device parameter missing}"
+image_path="${2:?image path parameter missing}"
+target_device_name="${3:?target device name parameter missing}"
+
+if [ "$#" != "3" ]; then
+  shift; shift; shift
+  echo "$0: extra parameters: $@" >&2
+  exit 1
+fi
+
+if ! fstype=$(lsblk --noheadings -o FSTYPE "${host_device}"); then
+  echo "image-boot: failed to detect filesystem type for ${host_device}" >&2
+  exit 1
+fi
+
+# Identify the EOS image extents on the host device, and create a dm-linear
+# block device that maps exactly to that.
+case "${fstype}" in
+exfat)
+  extents=$(dumpexfat -f "${image_path}" "${host_device}")
+  ;;
+ntfs)
+  extents=$(ntfsextents "${host_device}" "${image_path}")
+  ;;
+*)
+  echo "image-boot: unsupported filesystem ${fstype}" >&2
+  exit 1
+esac
+
+if [ $? != 0 ]; then
+  echo "image-boot: failed to lookup image ${image_path} on device ${host_device}" >&2
+  exit 1
+fi
+
+offset=0
+echo "$extents" | while read extent_offset extent_size; do
+  [ -z "${extent_offset}" -o -z "${extent_size}" ] && continue
+  # Convert bytes to sectors, failing if not aligned
+  if [ $(( extent_size % 512 )) != 0 ]; then
+    echo "image-boot: extent size $extent_size not sector-aligned" >&2
+    exit 1
+  fi
+  extent_size=$(( extent_size / 512 ))
+  extent_offset=$(( extent_offset / 512 ))
+  echo "${offset} ${extent_size} linear ${host_device} $extent_offset"
+  offset=$((offset + extent_size))
+done > /tmp/dmtable
+
+if [ $? != 0 ]; then
+  exit 1
+fi
+
+dmsetup create $target_device_name $dm_roflag < /tmp/dmtable
+if [ $? != 0 ]; then
+  echo "image-boot: failed to set up linear mapping" >&2
+  exit 1
+fi
+
+exit 0

--- a/dracut/image-boot/module-setup.sh
+++ b/dracut/image-boot/module-setup.sh
@@ -1,4 +1,4 @@
-# Copyright (C) 2016 Endless Mobile, Inc.
+# Copyright (C) 2016-2017 Endless Mobile, Inc.
 # Licensed under the GPLv2
 
 check() {
@@ -15,6 +15,7 @@ install() {
   inst_rules 55-dm.rules 60-cdrom_id.rules
   inst_script "$moddir"/eos-image-boot-setup /bin/eos-image-boot-setup
   inst_script "$moddir"/eos-live-early-overlayfs-setup /bin/eos-live-early-overlayfs-setup
+  inst_script "$moddir"/eos-map-image-file /bin/eos-map-image-file
   inst_simple "$moddir"/eos-image-boot-setup.service \
 	"$systemdsystemunitdir"/eos-image-boot-setup.service
   inst_simple "$moddir"/eos-live-early-overlayfs-setup.service \

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -3,5 +3,6 @@ TESTS = \
 
 EXTRA_DIST = \
 	$(TESTS) \
+	run-tests \
 	test_repartition.py \
 	$(NULL)

--- a/tests/check-syntax
+++ b/tests/check-syntax
@@ -8,11 +8,7 @@ ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))
 def find_files(pattern):
     '''Find files matching 'pattern' on the first line.'''
     output = subprocess.check_output([
-        'grep', '-r', '--files-with-match', '--null',
-        # Only first line
-        '--max-count', '1',
-        # Skip .git and friends
-        '--exclude-dir=.*',
+        'git', 'grep', '--files-with-match', '--null',
         pattern, ROOT
     ])
     return [x.decode('utf-8') for x in output.split(b'\x00') if x]

--- a/tests/run-tests
+++ b/tests/run-tests
@@ -1,0 +1,9 @@
+#!/bin/bash
+set -e
+
+cd "$(dirname "$0")"
+if pytest=$(which py.test-3); then
+    exec "$pytest" "$@"
+else
+    exec python3 -m unittest discover --top-level-directory .. "$@"
+fi

--- a/tests/test_image_boot.py
+++ b/tests/test_image_boot.py
@@ -1,0 +1,230 @@
+#!/usr/bin/env python3
+'''
+Must be run as a user privileged enough to run
+`losetup`. If run as an unprivileged user, all tests are skipped.
+'''
+
+import contextlib
+import os
+import tempfile
+import shutil
+import subprocess
+import unittest
+
+from .util import (
+    BaseTestCase,
+    dracut_script,
+    mount,
+    partprobe,
+    sfdisk,
+    get_lsblk_field,
+    udevadm_settle,
+)
+
+EOS_MAP_IMAGE_FILE = dracut_script('image-boot', 'eos-map-image-file')
+EOS_IMAGE_BOOT_SETUP = dracut_script('image-boot', 'eos-image-boot-setup')
+
+
+class ImageTestCase(BaseTestCase):
+    '''Base class for image-boot tests.'''
+    @contextlib.contextmanager
+    def make_host_device(self, filesystem):
+        '''Yields the path to a temporary loopback device, formatted as
+        'filesystem' by running 'mkfs', to host test image files.'''
+        mkfs = 'mkfs.{}'.format(filesystem)
+        with tempfile.NamedTemporaryFile() as host_img:
+            host_img.truncate(2 * 1024 * 1024)
+            sfdisk(host_img.name, b'start=64KiB, type=0x07')
+
+            with self.losetup(host_img.name) as host_disk:
+                partprobe(host_disk)
+                udevadm_settle()
+
+                host_device = host_disk + 'p1'
+                subprocess.check_call([mkfs, host_device])
+                partprobe(host_disk)
+                udevadm_settle()
+                self.assert_fstype(host_device, filesystem)
+
+                yield host_device
+
+    def assert_readonly(self, device, readonly):
+        self.assertEqual(
+            get_lsblk_field(device, 'ro'),
+            '1' if readonly else '0')
+
+
+class TestImageBootSetup(ImageTestCase):
+    '''Tests entire eos-image-boot-setup script.'''
+    def setUp(self):
+        self.tmpdir = tempfile.mkdtemp()
+        self.endless_img = os.path.join(self.tmpdir, 'endless.img')
+
+        with open(self.endless_img, 'wb') as f:
+            f.truncate(1 * 1024 * 1024)
+            sfdisk(f.name,
+                   b'start=64KiB, type=4F68BCE3-E8CD-4DB1-96E7-FBCAF984B709',
+                   label='gpt')
+
+    def tearDown(self):
+        shutil.rmtree(self.tmpdir)
+
+    def _mkisofs(self, *contents):
+        endless_iso = os.path.join(self.tmpdir, 'endless.iso')
+        subprocess.check_call((
+            'xorriso', '-as', 'mkisofs',
+            '-o', endless_iso,
+        ) + contents)
+        return endless_iso
+
+    def _mksquashfs(self, *contents):
+        endless_squash = os.path.join(self.tmpdir, 'endless.squash')
+        subprocess.check_call(('mksquashfs',) + contents + (endless_squash,))
+        return endless_squash
+
+    @unittest.expectedFailure
+    def test_image_boot_iso(self):
+        '''Tests ISO > uncompressed image'''
+        iso = self._mkisofs(self.endless_img)
+        with self.losetup(iso) as host_device:
+            self._go(host_device, 'endless.img', readonly=True)
+
+    def test_image_boot_iso_squashfs(self):
+        '''Tests ISO > SquashFS > uncompressed image'''
+        iso = self._mkisofs(self._mksquashfs(self.endless_img))
+        with self.losetup(iso) as host_device:
+            self._go(host_device, 'endless.squash', readonly=True)
+
+    def test_image_boot_exfat(self):
+        '''Tests exFAT > uncompressed image'''
+        with self.make_host_device('exfat') as host_device:
+            with mount(host_device) as host_mount:
+                shutil.copyfile(self.endless_img, host_mount + '/endless.img')
+
+            self._go(host_device, 'endless.img', readonly=False)
+
+    @unittest.expectedFailure
+    def test_image_boot_exfat_squashfs(self):
+        '''Tests exFAT > SquashFS > uncompressed image'''
+        endless_squash = self._mksquashfs(self.endless_img)
+        with self.make_host_device('exfat') as host_device:
+            with mount(host_device) as host_mount:
+                shutil.copyfile(endless_squash, host_mount + '/endless.squash')
+
+            self._go(host_device, 'endless.squash', readonly=True)
+
+    def test_image_boot_ntfs(self):
+        '''Tests NTFS > uncompressed image'''
+        with self.make_host_device('ntfs') as host_device:
+            with mount(host_device) as host_mount:
+                shutil.copyfile(self.endless_img, host_mount + '/endless.img')
+
+            self._go(host_device, 'endless.img', readonly=False)
+
+    def _detach_if_exists(self, image):
+        if os.path.exists(image):
+            dev = subprocess.check_output((
+                'losetup', '--output', 'NAME', '--noheadings',
+                '--associated', image,
+            ))
+            subprocess.call(('losetup', '--detach', dev.strip()))
+
+    def _go(self, host_device, image_path, readonly=False):
+        # The partition number is prefixed with 'p' iff the base device name
+        # ends in a digit
+        target_name = os.path.basename(self.tmpdir) + '0'
+        mapped_dev = '/dev/mapper/{}'.format(target_name)
+        mapped_part = '/dev/mapper/{}p1'.format(target_name)
+
+        try:
+            # Allow eos-image-boot-setup to find eos-map-image-file
+            env = dict(os.environ)
+            env['PATH'] = ':'.join((
+                os.path.dirname(EOS_IMAGE_BOOT_SETUP),
+                env['PATH'],
+            ))
+            args = [EOS_IMAGE_BOOT_SETUP, host_device, image_path, target_name]
+            if readonly:
+                args.insert(1, '--readonly')
+            subprocess.check_call(args, env=env)
+            udevadm_settle()
+            self.assertTrue(os.path.exists(mapped_dev))
+            self.assert_readonly(mapped_dev, readonly)
+            self.assertTrue(os.path.exists(mapped_part))
+            self.assert_readonly(mapped_part, readonly)
+            # We could be more zealous about checking the contents of the
+            # mapped partition, but TestMapImageFile -- plus the fact the
+            # partition was found within the device -- is good enough.
+        finally:
+            # This cleanup is all best-effort and reliant on implementation
+            # details of eos-image-boot-setup, whose effects are not really
+            # intended to be undone -- in normal use, the mapped OS image and
+            # everything behind it must exist until the machine is shut down.
+            subprocess.call(('kpartx', '-d', '-v', mapped_dev))
+            subprocess.call(('dmsetup', 'remove', target_name))
+
+            self._detach_if_exists('/squash/endless.img')
+            if os.path.exists('/squash'):
+                subprocess.call(('umount', '/squash'))
+                os.rmdir(('/squash'))
+
+            self._detach_if_exists('/cd/endless.squash')
+            self._detach_if_exists('/cd/endless.img')
+
+            if os.path.exists('/cd'):
+                subprocess.call(('umount', '/cd'))
+                os.rmdir('/cd')
+
+
+class TestMapImageFile(ImageTestCase):
+    '''Tests eos-map-image-file can correctly map a file within an unmounted
+    filesystem via device-mapper.'''
+
+    def test_map_exfat_readwrite(self):
+        '''Tests mapping a file on an exFAT filesystem.'''
+        self._go('exfat', readonly=False)
+
+    def test_map_ntfs_readwrite(self):
+        '''Tests mapping a file on an NTFS filesystem.'''
+        self._go('ntfs', readonly=False)
+
+    def test_map_exfat_readonly(self):
+        '''Tests mapping a file on an exFAT filesystem, readonly.'''
+        self._go('exfat', readonly=True)
+
+    def test_map_ntfs_readonly(self):
+        '''Tests mapping a file on an NTFS filesystem, readonly.'''
+        self._go('ntfs', readonly=True)
+
+
+    # TODO: would be nice to verify that eos-map-image-file fails if the file
+    # has holes or is not fully initialized on NTFS
+
+    def _go(self, filesystem, readonly=False):
+        image_path = 'foo'
+        image_data = b'0123456789abcdef' * 256
+
+        with self.make_host_device(filesystem) as host_device:
+            with mount(host_device) as host_mount:
+                full_path = os.path.join(host_mount, image_path)
+                with open(full_path, 'wb') as image:
+                    image.write(image_data)
+
+            # Assumes that the temp file's basename is not in use in
+            # device-mapper -- quite a safe assumption but not guaranteed.
+            dm_name = os.path.basename(host_device)
+            dm_path = os.path.join('/dev/mapper', dm_name)
+
+            args = [EOS_MAP_IMAGE_FILE, host_device, image_path, dm_name]
+            if readonly:
+                args.insert(1, "--readonly")
+            subprocess.check_call(args)
+
+            try:
+                with open(dm_path, 'rb') as mapped_image:
+                    mapped_data = mapped_image.read(len(image_data))
+                    self.assertEqual(mapped_data, image_data)
+
+                self.assert_readonly(dm_path, readonly)
+            finally:
+                subprocess.check_call(['dmsetup', 'remove', dm_name])

--- a/tests/test_image_boot.py
+++ b/tests/test_image_boot.py
@@ -103,7 +103,6 @@ class TestImageBootSetup(ImageTestCase):
 
             self._go(host_device, 'endless.img', readonly=False)
 
-    @unittest.expectedFailure
     def test_image_boot_exfat_squashfs(self):
         '''Tests exFAT > SquashFS > uncompressed image'''
         endless_squash = self._mksquashfs(self.endless_img)
@@ -167,6 +166,9 @@ class TestImageBootSetup(ImageTestCase):
             if os.path.exists('/squash'):
                 subprocess.call(('umount', '/squash'))
                 os.rmdir(('/squash'))
+
+            target_squash = target_name + '-squashfs'
+            subprocess.call(('dmsetup', 'remove', target_squash))
 
             self._detach_if_exists('/cd/endless.squash')
             self._detach_if_exists('/cd/endless.img')

--- a/tests/test_image_boot.py
+++ b/tests/test_image_boot.py
@@ -82,7 +82,6 @@ class TestImageBootSetup(ImageTestCase):
         subprocess.check_call(('mksquashfs',) + contents + (endless_squash,))
         return endless_squash
 
-    @unittest.expectedFailure
     def test_image_boot_iso(self):
         '''Tests ISO > uncompressed image'''
         iso = self._mkisofs(self.endless_img)

--- a/tests/test_repartition.py
+++ b/tests/test_repartition.py
@@ -139,7 +139,3 @@ start=   482312879, size=    17825792, type=EBD0A0A2-B9E5-4433-87C0-68B6B72699C7
         '''Asserts that 'partition' contains a 'type_' filesystem.'''
         msg = 'expected {} to have type {!r}'.format(partition, type_)
         self.assertEqual(fstype(partition), type_, msg=msg)
-
-
-if __name__ == '__main__':
-    unittest.main()

--- a/tests/test_repartition.py
+++ b/tests/test_repartition.py
@@ -3,48 +3,22 @@
 Tests endless-repartition.sh. Must be run as a user privileged enough to run
 `losetup`. If run as an unprivileged user, all tests are skipped.
 '''
-import contextlib
-import os
 import subprocess
 import tempfile
-import unittest
+
+from .util import (
+    BaseTestCase,
+    dracut_script,
+    partprobe,
+    sfdisk,
+    udevadm_settle,
+)
 
 
-ENDLESS_REPARTITION_SH = os.path.abspath(
-    os.path.join(
-        os.path.dirname(__file__),
-        '../dracut/repartition/endless-repartition.sh'))
+ENDLESS_REPARTITION_SH = dracut_script('repartition', 'endless-repartition.sh')
 
 
-def partprobe(device):
-    subprocess.check_call(['partprobe', device])
-
-
-def udevadm_settle():
-    subprocess.check_call(['udevadm', 'settle'])
-
-
-def fstype(device):
-    return subprocess.check_output([
-        'lsblk', '--noheading', '--output', 'fstype', device
-    ]).decode('utf-8').strip()
-
-
-class TestRepartition(unittest.TestCase):
-    @contextlib.contextmanager
-    def losetup(self, path):
-        try:
-            output = subprocess.check_output(['losetup', '--find', '--show', path])
-        except subprocess.CalledProcessError:
-            self.skipTest(reason='losetup failed (not running as root?)')
-
-        device = output.decode('utf-8').strip()
-        try:
-            partprobe(device)
-            yield device
-        finally:
-            subprocess.check_call(['losetup', '--detach', device])
-
+class TestRepartition(BaseTestCase):
     def test_creates_swap(self):
         '''
         This disk is big, so we should create a swap partition at the end.
@@ -105,9 +79,7 @@ start=   482312879, size=    17825792, type=EBD0A0A2-B9E5-4433-87C0-68B6B72699C7
     def _go(self, disk_size_bytes, partition_table, bd_pre=None, bd_post=None, swap=None):
         with tempfile.NamedTemporaryFile() as img:
             img.truncate(disk_size_bytes)
-            sfdisk = subprocess.Popen(["sfdisk", img.name], stdin=subprocess.PIPE)
-            sfdisk.communicate(partition_table)
-            self.assertEqual(sfdisk.returncode, 0, 'sfdisk failed')
+            sfdisk(img.name, partition_table)
 
             with self.losetup(img.name) as img_device:
                 try:
@@ -134,8 +106,3 @@ start=   482312879, size=    17825792, type=EBD0A0A2-B9E5-4433-87C0-68B6B72699C7
                     # Pause
                     # subprocess.check_call(["cat"])
                     raise
-
-    def assert_fstype(self, partition, type_):
-        '''Asserts that 'partition' contains a 'type_' filesystem.'''
-        msg = 'expected {} to have type {!r}'.format(partition, type_)
-        self.assertEqual(fstype(partition), type_, msg=msg)

--- a/tests/util.py
+++ b/tests/util.py
@@ -1,0 +1,60 @@
+import contextlib
+import subprocess
+import unittest
+import os
+
+
+def dracut_script(module, script):
+    '''Gets the absolute path to a script in a dracut module in this
+    repository.'''
+    return os.path.abspath(
+        os.path.join(
+            os.path.dirname(__file__),
+            '../dracut',
+            module,
+            script))
+
+
+def partprobe(device):
+    subprocess.check_call(['partprobe', device])
+
+
+def udevadm_settle():
+    subprocess.check_call(['udevadm', 'settle'])
+
+
+def fstype(device):
+    return subprocess.check_output([
+        'lsblk', '--noheading', '--output', 'fstype', device
+    ]).decode('utf-8').strip()
+
+
+def sfdisk(device, partition_table):
+    args = ("sfdisk", device)
+    sfdisk_proc = subprocess.Popen(args, stdin=subprocess.PIPE)
+    sfdisk_proc.communicate(partition_table)
+    if sfdisk_proc.returncode:
+        raise subprocess.CalledProcessError(sfdisk_proc.returncode, args)
+
+
+class BaseTestCase(unittest.TestCase):
+    @contextlib.contextmanager
+    def losetup(self, path):
+        '''Yields a loopback device for path.'''
+        try:
+            args = ('losetup', '--find', '--show', path,)
+            output = subprocess.check_output(args)
+        except subprocess.CalledProcessError:
+            self.skipTest(reason='losetup failed (not running as root?)')
+
+        device = output.decode('utf-8').strip()
+        try:
+            partprobe(device)
+            yield device
+        finally:
+            subprocess.check_call(['losetup', '--detach', device])
+
+    def assert_fstype(self, partition, type_):
+        '''Asserts that 'partition' contains a 'type_' filesystem.'''
+        msg = 'expected {} to have type {!r}'.format(partition, type_)
+        self.assertEqual(fstype(partition), type_, msg=msg)


### PR DESCRIPTION
I'm working on making the Installer for Windows operate on ISOs rather than on raw disk images, and I'm hoping to improve the USB stick creation process at the same time.

For starters: many users are surprised that they need a 32GiB USB stick for many Full images, despite the (compressed) download size being less than 16G(i)B. Even if we keep the current approach of putting the image file within a big exFAT partition on the USB stick (which is good, because it keeps the free space on the USB stick usable), it'd be nice if we could put the squashfs from inside the ISO onto that exFAT partition.

It'd also be nice to be able to reuse more of Rufus's USB stick creation code. Ours is a bit unreliable on Windows; of course, all bugs can be fixed, but if we can just lean on Rufus' (presumably) better-tested code this would be less work in the long run, and might even allow us to get patches into upstream Rufus so it can operate on our ISOs in non-`dd` mode.

I've tested this against the latest `eos3.2` image and it works, both with and without squashfs, because @carlocaione wisely made the embedded GRUB config search for `/endless/grub/grub.cfg` rather than `/endless/endless.{img,squash}` so the same GRUB blobs work.

https://phabricator.endlessm.com/T15890
https://phabricator.endlessm.com/T14312