### PR TITLE
debian/rules: remove extra list of .service files

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -9,14 +9,7 @@ override_dh_systemd_start:
 # don't automatically enable eos-firewall-localonly
 override_dh_systemd_enable:
 	dh_systemd_enable \
-	    eos-add-flatpak-gnome-repos.service \
-	    eos-enable-extra-upgrade.service \
-	    eos-enable-zram.service \
-	    eos-firstboot.service \
-	    eos-fix-flatpak-branches.service \
-	    eos-fix-home-dir-permissions.service \
-	    eos-image-boot-dm-setup.service \
-	    eos-live-boot-overlayfs-setup.service \
+	    -Xeos-firewall-localonly.service \
 	    $(NULL)
 	dh_systemd_enable --no-enable \
 	    eos-firewall-localonly.service \


### PR DESCRIPTION
The purpose of `override_dh_systemd_enable` here is to pass `--no-enable` for `eos-firewall-localonly.service` but enable all other services. But listing the `.service` files directly is error-prone -- it means that any new `.service` files added to the package need to be added to this list too. `eos-add-flatpak-apps-repos.service` and `eos-migrate-image-defaults.service` were not included here when they were added to the package, so did not run on converted systems.

When invoked without any unit files, `dh_systemd_enable` operates on all units installed by the package which contain an `[Install]` section.  Debhelper provides a `-X` option which can be used to exclude items from processing. This better expresses the intent of this rule -- enable all services, except `eos-firewall-localonly` -- and fixes the two existing bugs.

https://phabricator.endlessm.com/T15704