### PR TITLE
image-boot-dm-setup: don't spuriously fail on iso9660

### DIFF
--- a/eos-image-boot-dm-setup
+++ b/eos-image-boot-dm-setup
@@ -47,8 +47,9 @@ ntfs)
   extents=$(ntfsextents "${host_device}" "${image_path}")
   ;;
 *)
-  echo "Unsupported filesystem ${fstype} on ${host_device}"
-  exit 1
+  # No overlay necessary on filesystems where we use normal loopback mounts
+  # (eg iso9660).
+  exit 0
 esac
 
 if [ $? != 0 ]; then


### PR DESCRIPTION
When booting from an ISO, we currently see the following in the journal:

    systemd[1]: Starting Endless image boot device mapper setup...
    eos-image-boot-dm-setup[405]: Unsupported filesystem iso9660 on /dev/disk/by-uuid/2017-06-26-08-14-09-00
    systemd[1]: eos-image-boot-dm-setup.service: Main process exited, code=exited, status=1/FAILURE
    systemd[1]: Failed to start Endless image boot device mapper setup.
    systemd[1]: eos-image-boot-dm-setup.service: Unit entered failed state.
    systemd[1]: eos-image-boot-dm-setup.service: Failed with result 'exit-code'.

The failure is also visible on the console. But this job is only needed when booted from an image on an NTFS or exFAT partition, where the root device is mapped with device-mapper and so the host partition can't be mounted directly. When booted from iso9660, we use a normal loopback device, and the host partition can be mounted directly. So the error is spurious and confusing.

Spotted while trying to debug https://phabricator.endlessm.com/T17850 though this does not fix that issue.

I'd welcome suggestions for a more descriptive name for this unit -- I always misread it as being the main image-boot script run from the initramfs.