### PR TITLE
Fix /var on live boots with new ostree

### DIFF
--- a/dracut/image-boot/eos-live-early-overlayfs-setup
+++ b/dracut/image-boot/eos-live-early-overlayfs-setup
@@ -4,7 +4,7 @@
 
 type getarg >/dev/null 2>&1 || . /lib/dracut-lib.sh
 
-early_overlay_dirs="etc var"
+early_overlay_dirs="etc"
 for dir in $early_overlay_dirs; do
 	[ -d /$dir ] || continue
 	# If the directory is a symlink, assume it's pointing to a location

--- a/eos-image-boot-dm-setup
+++ b/eos-image-boot-dm-setup
@@ -47,8 +47,9 @@ ntfs)
   extents=$(ntfsextents "${host_device}" "${image_path}")
   ;;
 *)
-  echo "Unsupported filesystem ${fstype} on ${host_device}"
-  exit 1
+  # No overlay necessary on filesystems where we use normal loopback mounts
+  # (eg iso9660).
+  exit 0
 esac
 
 if [ $? != 0 ]; then

--- a/eos-live-boot-overlayfs-setup
+++ b/eos-live-boot-overlayfs-setup
@@ -47,7 +47,7 @@ setup_ostree_flatpak_overlay() {
 setup_ostree_flatpak_overlay
 
 # Everything else is pretty straightforward:
-overlay_dirs="bin boot endless home lib opt ostree root sbin srv sysroot/home"
+overlay_dirs="bin boot endless home lib opt ostree root sbin srv sysroot/home var"
 for dir in $overlay_dirs; do
     [ -d /$dir ] || continue
     [ -d /run/eos-live/$dir ] && continue

--- a/eos-live-boot-overlayfs-setup.service
+++ b/eos-live-boot-overlayfs-setup.service
@@ -2,7 +2,7 @@
 Description=Endless live boot overlayfs setup
 DefaultDependencies=no
 After=ostree-remount.service var.mount
-Before=local-fs.target
+Before=local-fs.target systemd-random-seed.service
 ConditionKernelCommandLine=endless.live_boot
 
 [Service]

--- a/eos-live-boot-overlayfs-setup.service
+++ b/eos-live-boot-overlayfs-setup.service
@@ -1,7 +1,7 @@
 [Unit]
 Description=Endless live boot overlayfs setup
 DefaultDependencies=no
-After=ostree-remount.service
+After=ostree-remount.service var.mount
 Before=local-fs.target
 ConditionKernelCommandLine=endless.live_boot
 


### PR DESCRIPTION
ostree's behaviour around mounting `/var` changed https://github.com/endlessm/ostree/commit/05d0ee5cbecd1287b87d38e969862a5d8b1f2e58 https://github.com/endlessm/ostree/commit/30705889cb867c18cdb7fed8e55dc46477c069fa and as a result, `/var` does not have the correct contents on live boots any more. Here, I attempt to fix this.

Tested by rebuilding the initrd and copying it and the other changes into the image on a combined USB.

https://phabricator.endlessm.com/T17622