### PR TITLE
Install com.endlessm.EknServices from eos-sdk

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -66,6 +66,7 @@ dist_sbin_SCRIPTS = \
 	eos-firstboot \
 	eos-fix-flatpak-branches \
 	eos-fix-home-dir-permissions \
+	eos-flatpak-change-origin \
 	eos-image-boot-dm-setup \
 	eos-live-boot-overlayfs-setup \
 	eos-migrate-image-defaults \

--- a/eos-add-flatpak-apps-repos
+++ b/eos-add-flatpak-apps-repos
@@ -34,23 +34,6 @@ flatpak remote-add --if-not-exists --from eos-sdk ${TMPDIR}/eos-sdk.flatpakrepo
 
 # Change com.endlessm.EknServices over to the version that uses the new runtime
 # in the eos-sdk repo
-cat <<EOF >${TMPDIR}/switch-eknservices.py
-import gi
-gi.require_version('Flatpak', '1.0')
-from gi.repository import Flatpak
-
-installation = Flatpak.Installation.new_system(cancellable=None)
-ref = installation.get_current_installed_app('com.endlessm.EknServices',
-                                             cancellable=None)
-old_origin = ref.props.origin
-ref.props.origin = 'eos-sdk'
-
-print('Switching com.endlessm.EknServices origin from', old_origin, 'to',
-      ref.props.origin)
-
-# FIXME need to write this back to the flatpak installation somehow!
-EOF
-
-python3 ${TMPDIR}/switch-eknservices.py
+eos-flatpak-change-origin com.endlessm.EknServices eos-sdk
 
 exit 0

--- a/eos-add-flatpak-apps-repos
+++ b/eos-add-flatpak-apps-repos
@@ -32,4 +32,25 @@ EOF
 # Add the repo only if not added yet
 flatpak remote-add --if-not-exists --from eos-sdk ${TMPDIR}/eos-sdk.flatpakrepo
 
+# Change com.endlessm.EknServices over to the version that uses the new runtime
+# in the eos-sdk repo
+cat <<EOF >${TMPDIR}/switch-eknservices.py
+import gi
+gi.require_version('Flatpak', '1.0')
+from gi.repository import Flatpak
+
+installation = Flatpak.Installation.new_system(cancellable=None)
+ref = installation.get_current_installed_app('com.endlessm.EknServices',
+                                             cancellable=None)
+old_origin = ref.props.origin
+ref.props.origin = 'eos-sdk'
+
+print('Switching com.endlessm.EknServices origin from', old_origin, 'to',
+      ref.props.origin)
+
+# FIXME need to write this back to the flatpak installation somehow!
+EOF
+
+python3 ${TMPDIR}/switch-eknservices.py
+
 exit 0

--- a/eos-flatpak-change-origin
+++ b/eos-flatpak-change-origin
@@ -1,0 +1,85 @@
+#!/usr/bin/python3
+#
+# eos-flatpak-change-origin: Hack to move a deployed Flatpak to another origin
+#
+# Copyright (C) 2017 Endless Mobile, Inc.
+# Authors:
+#  Mario Sanchez Prada <mario@endlessm.com>
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+
+import argparse
+import logging
+import os
+import shutil
+import tempfile
+
+import gi
+gi.require_version('Flatpak', '1.0')
+from gi.repository import Flatpak
+from gi.repository import Gio
+from gi.repository import GLib
+
+# Path to the flatpak system installation.
+FLATPAK_SYSTEM_INSTALLATION = '/var/lib/flatpak'
+
+def _update_deploy_file_for_app_and_remote(app_id, new_remote_name):
+    deploy_file_path = os.path.join(FLATPAK_SYSTEM_INSTALLATION,
+                                    'app', app_id, 'current', 'active', 'deploy')
+    logging.debug("Reading data from the deploy file at {}...".format(deploy_file_path))
+
+    src_file_contents = None
+    with open(deploy_file_path, 'rb') as f:
+        src_file_contents = GLib.Bytes.new(f.read())
+
+    # We need to read the GVariant in the deploy file and generate a
+    # new one with all the same content but the right remote set.
+    variant_type = GLib.VariantType.new('(ssasta{sv})')
+    orig_variant = GLib.Variant.new_from_bytes(variant_type, src_file_contents, False)
+    logging.debug("Original variant: {}".format(str(orig_variant)))
+
+    builder = GLib.VariantBuilder.new(variant_type)
+    for idx, val in enumerate(orig_variant):
+        # We just need to replace the first element in the Variant.
+        if idx == 0:
+            builder.add_value(GLib.Variant.new_string(new_remote_name))
+        else:
+            builder.add_value(orig_variant.get_child_value(idx))
+
+    new_variant = builder.end()
+    logging.debug("New variant: {}".format(str(new_variant)))
+
+    # Write the new GVariant to a temporary file and replace the original one.
+    with tempfile.NamedTemporaryFile() as tmp_deploy_file:
+        logging.info("Building new deploy file at {}, pointing to remote '{}'..."
+                     .format(tmp_deploy_file.name, new_remote_name))
+
+        # Write temporary file to disk and overwrite the original one with it.
+        dest_file = Gio.File.new_for_path(tmp_deploy_file.name)
+        out_stream = dest_file.append_to(Gio.FileCreateFlags.NONE, None)
+        out_stream.write_bytes(new_variant.get_data_as_bytes())
+
+        os.chmod(tmp_deploy_file.name, 0o644)
+        shutil.copy(tmp_deploy_file.name, deploy_file_path, follow_symlinks=True)
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser(description='Change origin of the given flatpak')
+    parser.add_argument('app_id', help='Flatpak app ID')
+    parser.add_argument('new_origin', help='New Flatpak origin')
+
+    parsed_args = parser.parse_args()
+    
+    _update_deploy_file_for_app_and_remote(parsed_args.app_id, parsed_args.new_origin)
+


### PR DESCRIPTION
When adding the new eos-sdk repo after an upgrade, make sure the only
installed copy of EknServices is the one published there. (We assume
that there is an internet connection since this script runs when we just
completed an OS upgrade.)

We remove any orphaned refs belonging to the old
com.endlessm.EknServices, though normal users would not have these
anyway.

https://phabricator.endlessm.com/T17863