### PR TITLE
eos-copy-host-mali-driver: Put GL driver in extension

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -20,6 +20,7 @@ dist_systemdunit_DATA = \
 	eos-fix-flatpak-branches.service \
 	eos-fix-home-dir-permissions.service \
 	eos-image-boot-dm-setup.service \
+	eos-link-host-mali-driver.service \
 	eos-live-boot-overlayfs-setup.service \
 	eos-migrate-image-defaults.service \
 	eos-remove-legacy-external-apps.service \
@@ -75,6 +76,7 @@ dist_sbin_SCRIPTS = \
 	eos-fix-flatpak-branches \
 	eos-fix-home-dir-permissions \
 	eos-image-boot-dm-setup \
+	eos-link-host-mali-driver \
 	eos-live-boot-overlayfs-setup \
 	eos-migrate-image-defaults \
 	eos-remove-legacy-external-apps \

--- a/eos-link-host-mali-driver
+++ b/eos-link-host-mali-driver
@@ -1,0 +1,35 @@
+#!/bin/sh -ex
+#
+# eos-link-host-mali-driver: Symlink the host's GL drivers into a flatpak local
+# extension directory.
+#
+# Copyright (C) 2017 Endless Mobile, Inc.
+# Authors:
+#  Philip Chimento <philip@endlessm.com>
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+
+EXTENSION_REF=org.freedesktop.Platform.GL.host/arm/1.6
+MALI_DIR=/usr/lib/arm-linux-gnueabihf/mali400-egl-x11
+
+DEST_DIR="/var/lib/flatpak/extension/$EXTENSION_REF"
+mkdir -p $(dirname "$DEST_DIR")
+ln -s "$MALI_DIR" "$DEST_DIR"
+
+if test -d /var/endless-extra/flatpak; then
+    DEST_DIR="/var/endless-extra/flatpak/extension/$EXTENSION_REF"
+    mkdir -p $(dirname "$DEST_DIR")
+    ln -s "$MALI_DIR" "$DEST_DIR"
+fi

--- a/eos-link-host-mali-driver.service
+++ b/eos-link-host-mali-driver.service
@@ -1,0 +1,22 @@
+# Symlink the host GL driver for Mali to a place where Flatpak will mount it
+
+[Unit]
+Description=Symlink Mali GL driver for Flatpak
+DefaultDependencies=no
+Conflicts=shutdown.target
+Wants=local-fs.target
+After=local-fs.target
+Before=multi-user.target
+
+# Only run on ARM systems with the Mali driver where we haven't run before
+ConditionArchitecture=arm
+ConditionPathExists=/usr/lib/arm-linux-gnueabihf/mali400-egl-x11
+ConditionPathExists=!/var/lib/flatpak/extension/org.freedesktop.Platform.GL.host/arm/1.6
+
+[Service]
+Type=oneshot
+RemainAfterExit=true
+ExecStart=/usr/sbin/eos-link-host-mali-driver
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
This symlinks the host GL Mali driver in
/usr/lib/arm-linux-gnueabihf/mali400-egl-x11 into a place where Flatpak
will hopefully look for it and mount it as an extension. This makes the
separate org.freedesktop.Platform.GL.mali450-blah-blah extension
unnecessary, as we can simply use the host's driver.

https://phabricator.endlessm.com/T18288