### PR TITLE
Explicitly setup /sysroot/boot -> /boot bind mount

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -9,6 +9,7 @@ AM_DISTCHECK_CONFIGURE_FLAGS = \
 	$(NULL)
 
 dist_systemdunit_DATA = \
+	boot.mount \
 	eos-add-flatpak-apps-repos.service \
 	eos-add-flatpak-gnome-repos.service \
 	eos-enable-extra-upgrade.service \

--- a/boot.mount
+++ b/boot.mount
@@ -1,0 +1,11 @@
+[Unit]
+ConditionKernelCommandLine=ostree
+
+[Mount]
+What=/sysroot/boot
+Where=/boot
+Type=none
+Options=bind
+
+[Install]
+WantedBy=local-fs.target

--- a/debian/eos-boot-helper.postinst
+++ b/debian/eos-boot-helper.postinst
@@ -7,5 +7,4 @@ rm -f /etc/systemd/system/local-fs.target.wants/eos-extra-resize.service
 rm -f "/etc/systemd/system/local-fs.target.wants/var-endless\x2dextra.mount" \
 	/etc/systemd/system/local-fs.target.wants/var-endlessx2dextra.mount
 rm -f /etc/systemd/system/local-fs.target.wants/sysroot-boot.mount
-rm -f /etc/systemd/system/local-fs.target.wants/boot.mount
 rm -rf /etc/systemd/system/"dev-disk-by\x2dlabel-eos\x2dswap.device.wants"


### PR DESCRIPTION
On OSTree systems, this is manually setup in the initrd by
ostree-prepare-root. But since it is not configured anywhere in the
system, systemd-gpt-auto-generator is not aware of it, and ends up
un-mounting it due to its own boot.mount and boot.automount units,
generated to mount the ESP on /boot.

We don't need to mount the ESP on EOS, and making this bind mount
explicit avoids this systemd-gpt-auto-generator's behaviour.

This effectively reverts commit
ccb3e26770ebbc7709a689497e7fbd59175e2638.

https://phabricator.endlessm.com/T18825