### PR TITLE
Clean up the legacy external apps remote and runtimes

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -22,6 +22,7 @@ dist_systemdunit_DATA = \
 	eos-image-boot-dm-setup.service \
 	eos-live-boot-overlayfs-setup.service \
 	eos-migrate-image-defaults.service \
+	eos-remove-legacy-external-apps.service \
 	$(NULL)
 
 dist_systemdgenerator_SCRIPTS = \
@@ -76,5 +77,6 @@ dist_sbin_SCRIPTS = \
 	eos-image-boot-dm-setup \
 	eos-live-boot-overlayfs-setup \
 	eos-migrate-image-defaults \
+	eos-remove-legacy-external-apps \
 	eos-repartition-mbr \
 	$(NULL)

--- a/eos-remove-legacy-external-apps
+++ b/eos-remove-legacy-external-apps
@@ -1,0 +1,34 @@
+#!/bin/bash -e
+# Copyright (C) 2017 Endless Mobile, Inc.
+# Licensed under the GPLv2
+
+# Legacy external apps had a runtime that was built locally
+# to contain the binaries (downloaded on the fly) of an app
+# that we didn't have the rights to distribute (like it's
+# currently done with Flatpak's extra-data).
+#
+# So it created a remote called 'eos-external-apps' in
+# '/var/lib/flatpak-external-apps'.
+#
+# The external apps in this case were Dropbox, Skype, and
+# Spotify.
+
+ext_apps_repo=/var/lib/flatpak-external-apps
+ext_apps_remote=eos-external-apps
+
+# Remove the 'eos-external-apps' remote
+flatpak remote-delete $ext_apps_remote || true
+
+# Remove the 'eos-external-apps' repo
+if [ -d $ext_apps_repo ]; then
+    rm -rf $ext_apps_repo
+fi
+
+# Remove legacy runtimes
+apps=(com.google.Chrome com.microsoft.Skype com.spotify.Client com.dropbox.Client)
+installed_runtimes=$(flatpak list --runtime)
+for app in ${apps[@]}; do
+	for installed_runtime in $(echo "$installed_runtimes" | grep "$app" | cut -d' ' -f1); do
+		flatpak uninstall $installed_runtime || true
+	done
+done

--- a/eos-remove-legacy-external-apps.service
+++ b/eos-remove-legacy-external-apps.service
@@ -1,0 +1,20 @@
+# Remove the Flatpak legacy apps remote and runtimes after an OS upgrade
+
+[Unit]
+Description=Remove the legacy Flatpak external apps' remote and runtimes
+DefaultDependencies=no
+Conflicts=shutdown.target
+Wants=local-fs.target
+After=local-fs.target
+
+# Only run on updates
+Before=multi-user.target systemd-update-done.service
+ConditionNeedsUpdate=/etc
+
+[Service]
+Type=oneshot
+RemainAfterExit=true
+ExecStart=/usr/sbin/eos-remove-legacy-external-apps
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
Since we no longer use the external apps implementation we did for
pre-3.1 releases, we should make sure that our users are not left
with runtimes occupying space, and the external apps remote just
resulting in potential bugs.

https://phabricator.endlessm.com/T14442