### PR TITLE
Import eos.preset from systemd package

### DIFF
--- a/50-eos.preset
+++ b/50-eos.preset
@@ -1,0 +1,69 @@
+# Systemd unit file presets for EOS. We do not install a wildcard
+# "disable *" rule, so here we simply blacklist any units that aren't
+# desired. All others will be enabled by systemd.
+
+# Reverse systemd defaults
+disable systemd-timesyncd.service
+disable systemd-networkd.service
+disable systemd-resolved.service
+disable systemd-networkd-wait-online.service
+
+# Disable other unwanted units
+disable bluetooth-init.service
+disable eos-firewall-localonly.service
+disable eos-update-server.service
+disable eos-update-server.socket
+disable eos-updater-avahi.path
+disable eos-updater-avahi.service
+disable NetworkManager-wait-online.service
+disable rtkit-daemon.service
+disable serial-getty@.service
+disable ssh*.service
+disable ssh.socket
+disable systemd-nspawn@.service
+disable wpa_supplicant@.service
+disable wpa_supplicant.service
+
+# Disable units masked by Debian, as systemctl preset-all fails to
+# handle them. Without this, `systemctl preset-all` will fail with:
+#
+# Operation failed: Cannot send after transport endpoint shutdown
+#
+# Units masked in systemd. See debian/systemd.links.
+disable x11-common.service
+disable hostname.service
+disable rmnologin.service
+disable bootmisc.service
+disable fuse.service
+disable bootlogd.service
+disable stop-bootlogd-single.service
+disable stop-bootlogd.service
+disable hwclock.service
+disable mountkernfs.service
+disable mountdevsubfs.service
+disable mountall.service
+disable mountall-bootclean.service
+disable mountnfs.service
+disable mountnfs-bootclean.service
+disable umountfs.service
+disable umountnfs.service
+disable umountroot.service
+disable checkfs.service
+disable checkroot.service
+disable checkroot-bootclean.service
+disable cryptdisks.service
+disable cryptdisks-early.service
+disable single.service
+disable killprocs.service
+disable sendsigs.service
+disable halt.service
+disable reboot.service
+disable rc.service
+disable rcS.service
+disable motd.service
+disable bootlogs.service
+#
+# Units masked by other packages. Run the following to find them:
+#
+# find /usr/lib/systemd/system -lname /dev/null -printf 'disable %f\n' | sort
+disable screen-cleanup.service

--- a/Makefile.am
+++ b/Makefile.am
@@ -1,10 +1,12 @@
 SUBDIRS = dracut tests
 EXTRA_DIST = debian
 
-# Install systemd units and generators and udev rules under $prefix for distcheck
+# Install systemd units, generators, preset files, and udev rules
+# under $prefix for distcheck
 AM_DISTCHECK_CONFIGURE_FLAGS = \
 	--with-systemdunitdir='$${prefix}/lib/systemd/system' \
 	--with-systemdgeneratordir='$${prefix}/lib/systemd/system-generators' \
+	--with-systemdpresetdir='$${prefix}/lib/systemd/system-preset' \
 	--with-udevdir='$${prefix}/lib/udev' \
 	$(NULL)
 
@@ -27,6 +29,10 @@ dist_systemdunit_DATA = \
 
 dist_systemdgenerator_SCRIPTS = \
 	eos-live-boot-generator \
+	$(NULL)
+
+dist_systemdpreset_DATA = \
+	50-eos.preset \
 	$(NULL)
 
 # Network Manager dispatcher script for the firewall - scripts which

--- a/configure.ac
+++ b/configure.ac
@@ -12,6 +12,9 @@ m4_define([no_systemd_error],
 m4_define([no_systemdsystemgeneratordir_error],
           [m4_normalize([Could not get systemdsystemgeneratordir setting from]
                         [systemd pkg-config file])])
+m4_define([no_systemdsystempresetdir_error],
+          [m4_normalize([Could not get systemdsystempresetdir setting from]
+                        [systemd pkg-config file])])
 m4_define([no_udev_error],
           [m4_normalize([Could not get udevdir setting from udev]
                         [pkg-config file])])
@@ -29,6 +32,13 @@ AC_ARG_WITH([systemdgeneratordir],
             [PKG_CHECK_VAR([systemdgeneratordir], [systemd],
                            [systemdsystemgeneratordir], [],
                            [AC_MSG_ERROR(no_systemd_error)])])
+AC_ARG_WITH([systemdpresetdir],
+            [AS_HELP_STRING([--with-systemdpresetdir],
+                            [Path to the system directory for systemd presets])],
+            [systemdpresetdir="$withval"],
+            [PKG_CHECK_VAR([systemdpresetdir], [systemd],
+                           [systemdsystempresetdir], [],
+                           [AC_MSG_ERROR(no_systemdsystempresetdir_error)])])
 AC_ARG_WITH([udevdir],
             [AS_HELP_STRING([--with-udevdir],
                             [Path to the system udev directory])],

--- a/configure.ac
+++ b/configure.ac
@@ -31,7 +31,7 @@ AC_ARG_WITH([systemdgeneratordir],
             [systemdgeneratordir="$withval"],
             [PKG_CHECK_VAR([systemdgeneratordir], [systemd],
                            [systemdsystemgeneratordir], [],
-                           [AC_MSG_ERROR(no_systemd_error)])])
+                           [AC_MSG_ERROR(no_systemdsystemgeneratordir_error)])])
 AC_ARG_WITH([systemdpresetdir],
             [AS_HELP_STRING([--with-systemdpresetdir],
                             [Path to the system directory for systemd presets])],

--- a/configure.ac
+++ b/configure.ac
@@ -6,7 +6,7 @@ PKG_PROG_PKG_CONFIG
 
 dnl Get systemd unit and udev rules directories. Add options so that they
 dnl can be set under $prefix for distcheck.
-m4_define([no_systemd_error],
+m4_define([no_systemdunitdir_error],
           [m4_normalize([Could not get systemdsystemunitdir setting from]
                         [systemd pkg-config file])])
 m4_define([no_systemdsystemgeneratordir_error],
@@ -24,7 +24,7 @@ AC_ARG_WITH([systemdunitdir],
             [systemdunitdir="$withval"],
             [PKG_CHECK_VAR([systemdunitdir], [systemd],
                            [systemdsystemunitdir], [],
-                           [AC_MSG_ERROR(no_systemd_error)])])
+                           [AC_MSG_ERROR(no_systemdunitdir_error)])])
 AC_ARG_WITH([systemdgeneratordir],
             [AS_HELP_STRING([--with-systemdgeneratordir],
                             [Path to the system directory for systemd generators])],

--- a/debian/control
+++ b/debian/control
@@ -20,3 +20,5 @@ Depends: ${misc:Depends},
          xinit,
          xterm,
          iptables,
+Breaks: systemd (<= 232+dev145.a41a4e3-23)
+Replaces: systemd (<= 232+dev145.a41a4e3-23)


### PR DESCRIPTION
We are currently wasting resources re-building systemd and
re-distributing all of systemd packages every time we change the preset
file. Let move it to a smaller package.

https://phabricator.endlessm.com/T11144