### PR TITLE
Add service to prevent adding ostree remotes in /etc/ostree/remotes.d

### DIFF
--- a/eos-add-flatpak-apps-repos.service
+++ b/eos-add-flatpak-apps-repos.service
@@ -11,6 +11,9 @@ After=local-fs.target
 Before=multi-user.target systemd-update-done.service
 ConditionNeedsUpdate=/var
 
+# Wait until the core.add-remotes-config-dir repo option is set
+After=eos-ostree-remotes-config.service
+
 [Service]
 Type=oneshot
 RemainAfterExit=true

--- a/eos-add-flatpak-flathub-repos.service
+++ b/eos-add-flatpak-flathub-repos.service
@@ -11,6 +11,9 @@ After=local-fs.target
 Before=multi-user.target systemd-update-done.service
 ConditionNeedsUpdate=/etc
 
+# Wait until the core.add-remotes-config-dir repo option is set
+After=eos-ostree-remotes-config.service
+
 [Service]
 Type=oneshot
 RemainAfterExit=true

--- a/eos-add-flatpak-gnome-repos.service
+++ b/eos-add-flatpak-gnome-repos.service
@@ -11,6 +11,9 @@ After=local-fs.target
 Before=multi-user.target systemd-update-done.service
 ConditionNeedsUpdate=/etc
 
+# Wait until the core.add-remotes-config-dir repo option is set
+After=eos-ostree-remotes-config.service
+
 [Service]
 Type=oneshot
 RemainAfterExit=true

--- a/eos-ostree-remotes-config
+++ b/eos-ostree-remotes-config
@@ -1,0 +1,43 @@
+#!/bin/bash -e
+
+# eos-ostree-remotes-config - configure /ostree/repo for safe remote adding
+#
+# Copyright (C) 2017 Endless Mobile, Inc.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, write to the Free Software Foundation, Inc.,
+# 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+# Set the repo config option core.add-remotes-config-dir repo option to
+# false so that new remotes are not added in /etc/ostree/remotes.d.
+# Adding them there is incompatible with the way flatpak modifies
+# remotes and will cause the repo to become unusable. Setting that
+# option to false ensures that ostree only adds remotes in the repo's
+# config file.
+#
+# This might only needed temporarily until ostree and flatpak get
+# updated to do sane remote modification.
+#
+# https://phabricator.endlessm.com/T19077
+# https://github.com/ostreedev/ostree/issues/1134
+
+# Check that /ostree/repo looks like a real repo
+[ -d /ostree/repo ] || exit 0
+[ -f /ostree/repo/config ] || exit 0
+[ -d /ostree/repo/objects ] || exit 0
+
+# Only set the option if it hasn't been set yet
+CONFIG_OPT="core.add-remotes-config-dir"
+if ! ostree --repo=/ostree/repo config get "$CONFIG_OPT" &>/dev/null; then
+    ostree --repo=/ostree/repo config set "$CONFIG_OPT" false
+fi

--- a/eos-ostree-remotes-config.service
+++ b/eos-ostree-remotes-config.service
@@ -1,0 +1,27 @@
+[Unit]
+Description=Set /ostree/repo config option core.add-remotes-config-dir false
+DefaultDependencies=no
+Conflicts=shutdown.target
+Wants=local-fs.target
+After=local-fs.target
+
+# Only needed if /ostree/repo exists
+ConditionPathIsDirectory=/ostree/repo
+
+# Only run on updates
+Before=multi-user.target systemd-update-done.service
+ConditionNeedsUpdate=|/etc
+ConditionNeedsUpdate=|/var
+
+# Try to run before any ostree clients so that they all see the updated
+# repo option
+Before=eos-autoupdater.service eos-updater.service
+Before=eos-updater-avahi.service eos-update-server.service
+
+[Service]
+Type=oneshot
+RemainAfterExit=true
+ExecStart=/usr/sbin/eos-ostree-remotes-config
+
+[Install]
+WantedBy=multi-user.target

--- a/eos-remove-legacy-external-apps.service
+++ b/eos-remove-legacy-external-apps.service
@@ -11,6 +11,9 @@ After=local-fs.target
 Before=multi-user.target systemd-update-done.service
 ConditionNeedsUpdate=/etc
 
+# Wait until the core.add-remotes-config-dir repo option is set
+After=eos-ostree-remotes-config.service
+
 [Service]
 Type=oneshot
 RemainAfterExit=true


### PR DESCRIPTION
Set the repo config option core.add-remotes-config-dir repo option to
false so that new remotes are not added in /etc/ostree/remotes.d. Adding
them there is incompatible with the way flatpak modifies remotes and
will cause the repo to become unusable. Setting that option to false
ensures that ostree only adds remotes in the repo's config file.

This might only needed temporarily until ostree and flatpak get updated
to do sane remote modification.

The service is only run on updates and before any known /ostree/repo
services. The other services here that modify the repo are setup to run
after this service. That was done to increase the likelihood that new
services copied from those will also run after this service.

https://phabricator.endlessm.com/T19077
https://github.com/ostreedev/ostree/issues/1134