### PR TITLE
Activate nvidia graphics driver on supported hardware

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -8,6 +8,7 @@ AM_DISTCHECK_CONFIGURE_FLAGS = \
 	--with-systemdgeneratordir='$${prefix}/lib/systemd/system-generators' \
 	--with-systemdpresetdir='$${prefix}/lib/systemd/system-preset' \
 	--with-udevdir='$${prefix}/lib/udev' \
+	--with-modprobedir='$${prefix}/lib/modprobe.d' \
 	$(NULL)
 
 dist_systemdunit_DATA = \
@@ -26,6 +27,7 @@ dist_systemdunit_DATA = \
 	eos-live-boot-overlayfs-setup.service \
 	eos-migrate-image-defaults.service \
 	eos-remove-legacy-external-apps.service \
+	nvidia-graphics.service \
 	$(NULL)
 
 dist_systemdgenerator_SCRIPTS = \
@@ -34,6 +36,10 @@ dist_systemdgenerator_SCRIPTS = \
 
 dist_systemdpreset_DATA = \
 	50-eos.preset \
+	$(NULL)
+
+dist_modprobe_DATA = \
+	nouveau.conf \
 	$(NULL)
 
 # Network Manager dispatcher script for the firewall - scripts which
@@ -87,4 +93,6 @@ dist_sbin_SCRIPTS = \
 	eos-migrate-image-defaults \
 	eos-remove-legacy-external-apps \
 	eos-repartition-mbr \
+	nvidia-graphics-cleanup \
+	nvidia-graphics-setup \
 	$(NULL)

--- a/configure.ac
+++ b/configure.ac
@@ -18,6 +18,7 @@ m4_define([no_systemdsystempresetdir_error],
 m4_define([no_udev_error],
           [m4_normalize([Could not get udevdir setting from udev]
                         [pkg-config file])])
+
 AC_ARG_WITH([systemdunitdir],
             [AS_HELP_STRING([--with-systemdunitdir],
                             [Path to the system directory for systemd units])],
@@ -46,6 +47,11 @@ AC_ARG_WITH([udevdir],
             [PKG_CHECK_VAR([udevdir], [udev],
                            [udevdir], [],
                            [AC_MSG_ERROR(no_udev_error)])])
+AC_ARG_WITH([modprobedir],
+            [AS_HELP_STRING([--with-modprobedir],
+                            [Path to the system modprobe.d directory])],
+            [modprobedir="$withval"], [modprobedir="/lib/modprobe.d"])
+AC_SUBST(modprobedir)
 
 AC_CONFIG_FILES([
 	Makefile

--- a/dracut/endless.conf
+++ b/dracut/endless.conf
@@ -1,3 +1,8 @@
 dracutmodules="dracut-systemd systemd-initrd dash drm eos-repartition eos-image-boot plymouth kernel-modules resume ostree systemd base fs-lib eos-customization"
 fscks="fsck fsck.ext4"
 filesystems="ext4 isofs"
+
+# Don't include nouveau in the initramfs, so that we can later choose
+# between nouveau and nvidia.
+# (nouveau cannot be unloaded after it has bound to a device)
+omit_drivers="nouveau"

--- a/nouveau.conf
+++ b/nouveau.conf
@@ -1,0 +1,3 @@
+# Prevent nouveau from being auto-loaded.
+# We load it conditionally from nvidia-graphics.service
+blacklist nouveau

--- a/nvidia-graphics-cleanup
+++ b/nvidia-graphics-cleanup
@@ -1,0 +1,11 @@
+#!/bin/bash
+shopt -s nullglob
+
+# If no user accounts are available, assume we're still in the factory
+# and hence properietary drivers should be erased
+homedirs=( /home/* )
+if [[ ${#homedirs[@]} == 0 ]]; then
+  rm -rf /var/lib/endless-external-drivers/nvidia
+fi
+
+exit 0

--- a/nvidia-graphics-setup
+++ b/nvidia-graphics-setup
@@ -1,0 +1,79 @@
+#!/bin/bash
+set -e
+
+NV_CURRENT=/usr/lib/nvidia/current
+NV_KERNEL_OBJ=${NV_CURRENT}/kernel-obj
+MODULE_DIR=/var/lib/endless-external-drivers/nvidia
+
+NV_DEVICE=$(lspci -mn | awk '{ gsub("\"",""); if (($2 == "0300" || $2 == "0302") && ($3 == "10de" || $3 == "12d2")) { print toupper($3)toupper($4) } }' | head -n 1)
+
+if [[ -z ${NV_DEVICE} ]]; then
+  exit 0
+fi
+
+echo "Found nvidia device ${NV_DEVICE}"
+
+# Build the nvidia module if we haven't already built the current
+# ostree-shipped driver version for the currently running kernel.
+build_nvidia_if_needed() {
+  local running_kernel_version=$(uname -r)
+  local nvidia_ostree_version
+  local built_driver_version
+  local built_kernel_version
+
+  if [[ -e "${NV_KERNEL_OBJ}/version" ]]; then
+    nvidia_ostree_version=$(<${NV_KERNEL_OBJ}/version)
+  fi
+  if [[ -e "${MODULE_DIR}/driver-version" ]]; then
+    built_driver_version=$(<${MODULE_DIR}/driver-version)
+  fi
+  if [[ -e "${MODULE_DIR}/kernel-version" ]]; then
+    built_kernel_version=$(<${MODULE_DIR}/kernel-version)
+  fi
+
+  echo "Kernel version: running=${running_kernel_version} built=${built_kernel_version}"
+  echo "Driver version: shipped=${nvidia_ostree_version} built=${built_driver_version}"
+
+  # If we've built the driver for the kernel we're running, and it's the same
+  # driver version as the one in the ostree, then we have nothing to do
+  if [[ "${built_kernel_version}" == "$(uname -r)" ]] &&
+     [[ "${built_driver_version}" == "${nvidia_ostree_version}" ]]; then
+    return
+  fi
+
+  # Otherwise, build needed.
+  echo "Building driver"
+  rm -rf "${MODULE_DIR}"
+  mkdir -p "${MODULE_DIR}"
+  OUTPREFIX="${MODULE_DIR}/" "${NV_KERNEL_OBJ}/build" || return
+  uname -r > "${MODULE_DIR}/kernel-version"
+  cp "${NV_KERNEL_OBJ}/version" "${MODULE_DIR}/driver-version"
+}
+
+if ! modprobe -c | grep -F -x --quiet "blacklist nvidia" &&
+   grep --quiet -F ${NV_DEVICE} ${NV_CURRENT}/nvidia.ids; then
+
+  build_nvidia_if_needed
+  echo "Loading nvidia modules"
+  insmod "${MODULE_DIR}"/nvidia.ko || :
+  insmod "${MODULE_DIR}"/nvidia-modeset.ko || :
+  insmod "${MODULE_DIR}"/nvidia-drm.ko || :
+  if [[ -e "/sys/module/nvidia_drm" ]]; then
+    echo "nvidia loaded successfully"
+    exit 0
+  fi
+
+  # Try to unload anything that loaded
+  echo "nvidia load failed"
+  ls /sys/module
+  rmmod nvidia-drm
+  rmmod nvidia-modeset
+  rmmod nvidia
+fi
+
+# nouveau selected, or we want to use nouveau because nvidia build/load failed
+
+# nouveau claims all devices based on the nvidia vendor IDs so we don't
+# need to do a specific product ID lookup here, just load it.
+echo "Loading nouveau"
+modprobe nouveau

--- a/nvidia-graphics.service
+++ b/nvidia-graphics.service
@@ -1,0 +1,12 @@
+[Unit]
+Description=Nvidia graphics management
+Before=gdm.service
+
+[Service]
+Type=oneshot
+RemainAfterExit=yes
+ExecStart=/usr/sbin/nvidia-graphics-setup
+ExecStop=/usr/sbin/nvidia-graphics-cleanup
+
+[Install]
+WantedBy=graphical.target


### PR DESCRIPTION
As nouveau is not supporting the latest nvidia hardware well enough,
we will now activate the nvidia driver automatically, when we detect
supported hardware.

Detection is done using PCI IDs, using the same technique
as Debian.

We have to remove nouveau from the initramfs, and blacklist it on
the real root, in order to stop it being loaded, since otherwise
we cannot unload it (to then load nvidia).

However, if nvidia load then fails, we fall back to nouveau.
We also fall back on nouveau if the user has blacklisted
nvidia in the regular modprobe configuration.

https://phabricator.endlessm.com/T19190