### PR TITLE
eos-link-host-mali-driver: Fix host path

### DIFF
--- a/eos-link-host-mali-driver
+++ b/eos-link-host-mali-driver
@@ -22,14 +22,14 @@
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
 EXTENSION_REF=org.freedesktop.Platform.GL.host/arm/1.6
-MALI_DIR=/usr/lib/arm-linux-gnueabihf/mali400-egl-x11
+MALI_DIR=/usr/lib/mali400/arm-linux-gnueabihf
 
 DEST_DIR="/var/lib/flatpak/extension/$EXTENSION_REF"
 mkdir -p $(dirname "$DEST_DIR")
-ln -s "$MALI_DIR" "$DEST_DIR"
+ln -sf "$MALI_DIR" "$DEST_DIR"
 
 if test -d /var/endless-extra/flatpak; then
     DEST_DIR="/var/endless-extra/flatpak/extension/$EXTENSION_REF"
     mkdir -p $(dirname "$DEST_DIR")
-    ln -s "$MALI_DIR" "$DEST_DIR"
+    ln -sf "$MALI_DIR" "$DEST_DIR"
 fi

--- a/eos-link-host-mali-driver.service
+++ b/eos-link-host-mali-driver.service
@@ -10,7 +10,7 @@ Before=multi-user.target
 
 # Only run on ARM systems with the Mali driver where we haven't run before
 ConditionArchitecture=arm
-ConditionPathExists=/usr/lib/arm-linux-gnueabihf/mali400-egl-x11
+ConditionPathExists=/usr/lib/mali400/arm-linux-gnueabihf
 ConditionPathExists=!/var/lib/flatpak/extension/org.freedesktop.Platform.GL.host/arm/1.6
 
 [Service]


### PR DESCRIPTION
With the work to support NVIDIA binary drivers we had to move our Mali
drivers to a different location. We need to adjust paths here
accordingly, overwriting the old link in case it exists.

ConditionPathExists= follows symbolic links, so the service will run
when upgrading on a system which already has the system pointing to the
old location.

https://phabricator.endlessm.com/T18579