### PR TITLE
eos-link-host-mali-driver: add libMali wrapper to fix missing symbol

### DIFF
--- a/eos-link-host-mali-driver
+++ b/eos-link-host-mali-driver
@@ -22,7 +22,7 @@
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
 EXTENSION_REF=org.freedesktop.Platform.GL.host/arm/1.6
-MALI_DIR=/usr/lib/mali400/arm-linux-gnueabihf
+MALI_DIR=/usr/lib/mali400/arm-linux-gnueabihf/flatpak
 
 DEST_DIR="/var/lib/flatpak/extension/$EXTENSION_REF"
 mkdir -p $(dirname "$DEST_DIR")


### PR DESCRIPTION
Our mali driver is compiled against a patched X11 library that has a
new symbol (XDisplaySetErrorHandler) which will not be present in
flatpak runtimes

Since we can not currently rebuild the driver the only solution is to add
a wrapper library that links with the driver and implements the missing symbol

https://phabricator.endlessm.com/T18288