### PR TITLE
build: Remove leftover reference to nvidia-graphics-cleanup

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -96,6 +96,5 @@ dist_sbin_SCRIPTS = \
 	eos-migrate-image-defaults \
 	eos-remove-legacy-external-apps \
 	eos-repartition-mbr \
-	nvidia-graphics-cleanup \
 	nvidia-graphics-setup \
 	$(NULL)


### PR DESCRIPTION
This fixes a build-failure fallout from the last PR.

https://phabricator.endlessm.com/T18676