### PR TITLE
Disable loading nvidia module by default

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -39,6 +39,7 @@ dist_systemdpreset_DATA = \
 
 dist_modprobe_DATA = \
 	nouveau.conf \
+	nvidia.conf \
 	$(NULL)
 
 # Network Manager dispatcher script for the firewall - scripts which

--- a/nvidia.conf
+++ b/nvidia.conf
@@ -1,0 +1,2 @@
+# Disable nvidia by default.
+blacklist nvidia


### PR DESCRIPTION
We found problems when trying to run flatpak apps that use the 3.2
runtime on systems where the nvidia driver is loaded. This disables
automatically loading the nvidia driver for now.

https://phabricator.endlessm.com/T19581