### PR TITLE
Setup flatpak extension directory on extra storage

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -25,6 +25,7 @@ dist_systemdunit_DATA = \
 	eos-ostree-remotes-config.service \
 	eos-remove-old-flatpak-extension-dir.service \
 	eos-remove-old-flatpak-extension-dir-extra.service \
+	eos-setup-flatpak-extension-dir-extra.service \
 	eos-update-flatpak-repos.service \
 	nvidia-graphics.service \
 	$(NULL)

--- a/eos-setup-flatpak-extension-dir-extra.service
+++ b/eos-setup-flatpak-extension-dir-extra.service
@@ -1,0 +1,11 @@
+[Unit]
+Description=Setup flatpak extension directory on extra storage
+ConditionPathExists=/var/endless-extra/flatpak
+
+[Service]
+Type=oneshot
+RemainAfterExit=yes
+ExecStart=/usr/bin/ln -snf /var/lib/flatpak/extension /var/endless-extra/flatpak/extension
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
On non-split systems /var/endless-extra does not exist, so if try to
create this symlink through a static tmpfile, systemd-tmpfiles returns
an error (although the other files are created correctly), causing
systemd-tmpfiles-setup.service to exit with a failure status.

Let's use a simple service unit to create it only on split-disk systems.

https://phabricator.endlessm.com/T19691