### PR TITLE
Don't run eos-setup-flatpak-extension-dir-extra on every boot

### DIFF
--- a/eos-remove-old-flatpak-extension-dir-extra.service
+++ b/eos-remove-old-flatpak-extension-dir-extra.service
@@ -1,15 +1,11 @@
 [Unit]
-Description=Remove old Flatpak unmanaged extensions directory from /var/endless-extra/flatpak
-DefaultDependencies=false
-Conflicts=shutdown.target
-Before=systemd-tmpfiles-setup.service
-After=local-fs.target
-Wants=local-fs.target
-
-# Only run on ARM systems where the old directory exists
+Description=Remove old Flatpak extension directory from extra storage
 ConditionArchitecture=arm
+ConditionPathIsMountPoint=/var/endless-extra
+ConditionPathExists=/var/endless-extra/flatpak
 ConditionPathIsDirectory=/var/endless-extra/flatpak/extension
 ConditionPathIsSymbolicLink=!/var/endless-extra/flatpak/extension
+Before=eos-setup-flatpak-extension-dir-extra.service
 
 [Service]
 Type=oneshot

--- a/eos-setup-flatpak-extension-dir-extra.service
+++ b/eos-setup-flatpak-extension-dir-extra.service
@@ -7,7 +7,7 @@ ConditionPathIsSymbolicLink=!/var/endless-extra/flatpak/extension
 [Service]
 Type=oneshot
 RemainAfterExit=yes
-ExecStart=/usr/bin/ln -snf /var/lib/flatpak/extension /var/endless-extra/flatpak/extension
+ExecStart=/usr/bin/ln -snf -t /var/endless-extra/flatpak /var/lib/flatpak/extension
 
 [Install]
 WantedBy=multi-user.target

--- a/eos-setup-flatpak-extension-dir-extra.service
+++ b/eos-setup-flatpak-extension-dir-extra.service
@@ -1,6 +1,8 @@
 [Unit]
-Description=Setup flatpak extension directory on extra storage
+Description=Setup Flatpak extension directory on extra storage
+ConditionPathIsMountPoint=/var/endless-extra
 ConditionPathExists=/var/endless-extra/flatpak
+ConditionPathIsSymbolicLink=!/var/endless-extra/flatpak/extension
 
 [Service]
 Type=oneshot


### PR DESCRIPTION
If the link already exists we don't need to spawn ln.

https://phabricator.endlessm.com/T19691