### PR TITLE
Fix ln path

### DIFF
--- a/eos-setup-flatpak-extension-dir-extra.service
+++ b/eos-setup-flatpak-extension-dir-extra.service
@@ -7,7 +7,7 @@ ConditionPathIsSymbolicLink=!/var/endless-extra/flatpak/extension
 [Service]
 Type=oneshot
 RemainAfterExit=yes
-ExecStart=/usr/bin/ln -snf -t /var/endless-extra/flatpak /var/lib/flatpak/extension
+ExecStart=/bin/ln -snf -t /var/endless-extra/flatpak /var/lib/flatpak/extension
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
This actually lives in /bin, not /usr/bin. Even tho /bin is a symlink to
/usr/bin, if we ever change this, or need to run this script on a
different setup for some reason, it is better to use the correct path.

https://phabricator.endlessm.com/T19691