### PR TITLE
Attach secure boot signatures to modules

### DIFF
--- a/nvidia-graphics-setup
+++ b/nvidia-graphics-setup
@@ -57,6 +57,13 @@ build_nvidia_if_needed() {
   rm -rf "${MODULE_DIR}"
   mkdir -p "${MODULE_DIR}"
   OUTPREFIX="${MODULE_DIR}/" "${NV_KERNEL_OBJ}/build" || return
+
+  # Append signatures, if we have them
+  local kmod
+  for kmod in ${MODULE_DIR}/*.ko; do
+    cat "${NV_KERNEL_OBJ}/$(basename $kmod).sig" >> ${kmod} 2>/dev/null || :
+  done
+
   uname -r > "${MODULE_DIR}/kernel-version"
   cp "${NV_KERNEL_OBJ}/version" "${MODULE_DIR}/driver-version"
 }


### PR DESCRIPTION
If present, we will now attach a signature to the modules we link.
The idea here is that the module linking is reproducible,
and the signature which we attach will be trusted and let the kernel
load the module even when secure boot is enabled.

https://phabricator.endlessm.com/T19170