### PR TITLE
service: Add eos-companion-app.service and socket activation

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -12,6 +12,8 @@ AM_DISTCHECK_CONFIGURE_FLAGS = \
 	$(NULL)
 
 dist_systemdunit_DATA = \
+	eos-companion-app.service \
+	eos-companion-app.socket \
 	eos-enable-extra-upgrade.service \
 	eos-enable-zram.service \
 	eos-extra-resize.service \

--- a/Makefile.am
+++ b/Makefile.am
@@ -81,6 +81,11 @@ dist_polkitrules_DATA = \
 	10-allow-mounting-endless-image-device.rules \
 	$(NULL)
 
+tmpfilesddir = $(prefix)/lib/tmpfiles.d
+dist_tmpfilesd_DATA = \
+	tmpfiles.d/eos-companion-app-helper.conf \
+	$(NULL)
+
 dist_sbin_SCRIPTS = \
 	eos-add-flatpak-apps-repos \
 	eos-add-flatpak-flathub-repos \

--- a/eos-companion-app.service
+++ b/eos-companion-app.service
@@ -1,0 +1,10 @@
+[Unit]
+Description=EOS Companion App Service
+After=network.target eos-companion-app.socket
+Requires=eos-companion-app.socket
+
+[Service]
+ExecStart=/usr/bin/flatpak run --no-desktop com.endlessm.CompanionAppService
+User=companion-app-helper
+
+PrivateTmp=yes

--- a/eos-companion-app.socket
+++ b/eos-companion-app.socket
@@ -1,0 +1,9 @@
+[Unit]
+Description=EOS Companion App Service
+PartOf=eos-companion-app.service
+
+[Socket]
+ListenStream=1110
+
+[Install]
+WantedBy=sockets.target

--- a/tmpfiles.d/eos-companion-app-helper.conf
+++ b/tmpfiles.d/eos-companion-app-helper.conf
@@ -1,0 +1,3 @@
+# Type Path    Mode UID  GID  Age Argument
+d /var/lib/companion-app-helper 0755 companion-app-helper companion-app-helper -
+Z /var/lib/companion-app-helper 0755 companion-app-helper companion-app-helper -


### PR DESCRIPTION
This will listen on port 1110 to launch the Companion App, if available.

https://phabricator.endlessm.com/T20130