### PR TITLE
eos-repartition-mbr: preserve ESP

### DIFF
--- a/eos-repartition-mbr
+++ b/eos-repartition-mbr
@@ -14,13 +14,13 @@ root_disk="$1"
 udevadm settle
 
 # take current partition table
-parts=$(sfdisk -d $root_disk)
+parts=$(sfdisk -d "$root_disk")
 
 check_partition_exists() {
-  local name=${1:?No name supplied to ${FUNCNAME}}
-  local guid=${2:?No GUID supplied to ${FUNCNAME}}
+  local name=${1:?No name supplied to ${FUNCNAME[0]}}
+  local guid=${2:?No GUID supplied to ${FUNCNAME[0]}}
 
-  if ! echo "$parts" | grep -iq "type=$2"; then
+  if ! echo "$parts" | grep -iq "type=$guid"; then
     echo "$0: $name partition not found" >&2
     exit 1
   fi
@@ -36,6 +36,10 @@ check_partition_exists "Endless OS root" "$dps_root_guid"
 # If any other partitions exist, the call to sfdisk with the modified table
 # will fail due to type=UUid being invalid with 'label: dos'
 
+# “See if you can use ${variable//search/replace} instead.” For some of these,
+# we cannot.
+# shellcheck disable=SC2001
+{
 # Reset partition indexes
 parts=$(echo "$parts" | sed -e "s/^\/[^: ]\+//")
 
@@ -52,31 +56,32 @@ parts=$(echo "$parts" | grep -v "$bios_boot_guid")
 parts=$(echo "$parts" | sed -e "s/, type=$dps_root_guid/, type=83, bootable/")
 # Remove partition UUIDs and GPT attributes
 parts=$(echo "$parts" | sed -e "s/, \(uuid\|attrs\)=[^\s,]\+//g")
+}
 
 echo "$parts"
-echo "$parts" | sfdisk --force --no-reread $root_disk
+echo "$parts" | sfdisk --force --no-reread "$root_disk"
 udevadm settle
 partprobe "${root_disk}"
 udevadm settle
 
 # Set marker on 4th partition so that the partition gets enlarged to fill the
 # disk on first boot
-printf "\xdd" | dd of=${root_disk} bs=1 count=1 seek=498 conv=notrunc
+printf "\xdd" | dd of="$root_disk" bs=1 count=1 seek=498 conv=notrunc
 udevadm settle
 
 # Remove GPT headers. It's a little tricky to work out where the backup one is
 # from sfdisk's output, but we can get it from the primary header:
 # https://en.wikipedia.org/wiki/GUID_Partition_Table#Partition_table_header_.28LBA_1.29
 backup_gpt_offset=$(
-  dd if=${root_disk} bs=1 count=8 skip=$(( 512 + 0x20 )) | python -c \
+  dd if="$root_disk" bs=1 count=8 skip=$(( 512 + 0x20 )) | python -c \
     'import sys, struct; print struct.unpack("<Q", sys.stdin.read(8))[0]'
 )
-backup_gpt="$(dd if=${root_disk} bs=512 skip=${backup_gpt_offset} count=1)"
+backup_gpt="$(dd if="$root_disk" bs=512 skip="$backup_gpt_offset" count=1)"
 if [ "${backup_gpt::8}" != "EFI PART" ]; then
   echo "$0: couldn't find backup GPT header at ${backup_gpt_offset}" >&2
   exit 1
 fi
-dd if=/dev/zero of=${root_disk} conv=fsync bs=512 count=1 seek=1
+dd if=/dev/zero of="$root_disk" conv=fsync bs=512 count=1 seek=1
 udevadm settle
-dd if=/dev/zero of=${root_disk} conv=fsync bs=512 count=1 seek=${backup_gpt_offset}
+dd if=/dev/zero of="$root_disk" conv=fsync bs=512 count=1 seek="$backup_gpt_offset"
 udevadm settle

--- a/eos-repartition-mbr
+++ b/eos-repartition-mbr
@@ -58,7 +58,6 @@ parts=$(echo "$parts" | sed -e "s/, type=$dps_root_guid/, type=83, bootable/")
 parts=$(echo "$parts" | sed -e "s/, \(uuid\|attrs\)=[^\s,]\+//g")
 }
 
-echo "$parts"
 echo "$parts" | sfdisk --force --no-reread "$root_disk"
 udevadm settle
 partprobe "${root_disk}"

--- a/eos-repartition-mbr
+++ b/eos-repartition-mbr
@@ -10,25 +10,6 @@ fi
 
 root_disk="$1"
 
-# check if we passed the full device file path
-if [ "${root_disk//dev/}" = "${root_disk}" ]; then
-  echo "$0: Specify the full path for the root device file (i.e. /dev/sda)" >&2
-  exit 1
-fi
-
-# check if the root disk exists
-if [ ! -e "$root_disk" ]; then
-  echo "$0: $root_disk doesn't exist" >&2
-  exit 1
-fi
-
-# check it's a disk (not a partition or non-block device)
-type="$(lsblk -o type --nodeps --noheadings "$root_disk")"
-if [ "$type" != "disk" ]; then
-  echo "$0: $root_disk isn't a disk, but a $type" >&2
-  exit 1
-fi
-
 # udev might still be busy probing the disk, meaning that it will be in use.
 udevadm settle
 
@@ -56,8 +37,7 @@ check_partition_exists "Endless OS root" "$dps_root_guid"
 # will fail due to type=UUid being invalid with 'label: dos'
 
 # Reset partition indexes
-root_disk_dev=${root_disk#/dev/}
-parts=$(echo "$parts" | sed -e "s/${root_disk_dev}[^: ]\+//")
+parts=$(echo "$parts" | sed -e "s/^\/[^: ]\+//")
 
 # GPT -> DOS
 parts=$(echo "$parts" | sed -e "s/label: gpt/label: dos/")

--- a/eos-repartition-mbr
+++ b/eos-repartition-mbr
@@ -35,7 +35,7 @@ udevadm settle
 # take current partition table
 parts=$(sfdisk -d $root_disk)
 
-find_partition_device() {
+check_partition_exists() {
   local name=${1:?No name supplied to ${FUNCNAME}}
   local guid=${2:?No GUID supplied to ${FUNCNAME}}
 
@@ -43,44 +43,17 @@ find_partition_device() {
     echo "$0: $name partition not found" >&2
     exit 1
   fi
-
-  echo "$parts" | grep -i "type=$2" | cut -d' ' -f1
 }
 
-find_and_remove_partition() {
-  local name=${1:?No name supplied to ${FUNCNAME}}
-  local guid=${2:?No GUID supplied to ${FUNCNAME}}
-
-  if ! echo "$parts" | grep -q "type=$guid"; then
-    echo "$0: $name partition not found" >&2
-    exit 1
-  fi
-
-  parts=$(echo "$parts" | grep -v "$guid")
-}
-
+esp_guid="C12A7328-F81F-11D2-BA4B-00A0C93EC93B"
+bios_boot_guid="21686148-6449-6E6F-744E-656564454649"
 dps_root_guid="4F68BCE3-E8CD-4DB1-96E7-FBCAF984B709"
-root_part=$(find_partition_device "Endless OS root" "$dps_root_guid")
-root_partno="${root_part: -1}"
-root_part_base="${root_part:: -1}"
 
-swap_partno=$((root_partno + 1))
-swap_part="${root_part_base}${swap_partno}"
-
-# check the last partition on the disk
-lastpart=$(echo "$parts" | sed -n -e '$ s/[^:]*\([0-9]\) :.*$/\1/p')
-
-if [ $lastpart -eq $swap_partno ]; then
-  # already have an extra partition, perhaps we were halfway through creating
-  # a swap partition but didn't finish. Remove it to try again below.
-  parts=$(echo "$parts" | sed '$d')
-elif [ $lastpart -gt $swap_partno ]; then
-  echo "repartition: found $lastpart partitions?" >&2
-  exit 1
-fi
-
-find_and_remove_partition "ESP" "C12A7328-F81F-11D2-BA4B-00A0C93EC93B"
-find_and_remove_partition "BIOS boot" "21686148-6449-6E6F-744E-656564454649"
+check_partition_exists "ESP" "$esp_guid"
+check_partition_exists "BIOS boot" "$bios_boot_guid"
+check_partition_exists "Endless OS root" "$dps_root_guid"
+# If any other partitions exist, the call to sfdisk with the modified table
+# will fail due to type=UUid being invalid with 'label: dos'
 
 # Reset partition indexes
 root_disk_dev=${root_disk#/dev/}
@@ -89,8 +62,13 @@ parts=$(echo "$parts" | sed -e "s/${root_disk_dev}[^: ]\+//")
 # GPT -> DOS
 parts=$(echo "$parts" | sed -e "s/label: gpt/label: dos/")
 
-# Set MBR partition type and mark as bootable (not strictly true, but our MBR
-# does not care - some BIOSes don't consider a drive to be bootable without it)
+# Set ESP partition type to EF
+parts=$(echo "$parts" | sed -e "s/, type=$esp_guid/, type=EF/")
+# Remove BIOS boot partition (but leave its former contents intact)
+parts=$(echo "$parts" | grep -v "$bios_boot_guid")
+# Set MBR partition type on root partition, and mark as bootable (not strictly
+# true, but our MBR does not care - some BIOSes don't consider a drive to be
+# bootable without it)
 parts=$(echo "$parts" | sed -e "s/, type=$dps_root_guid/, type=83, bootable/")
 # Remove partition UUIDs and GPT attributes
 parts=$(echo "$parts" | sed -e "s/, \(uuid\|attrs\)=[^\s,]\+//g")
@@ -125,7 +103,7 @@ udevadm settle
 
 # Restore bootloader
 root_mountpoint=$(mktemp -d)
-mount "${root_part_base}$((root_partno - 2))" ${root_mountpoint}
+mount "${root_part_base}$((root_partno - 1))" ${root_mountpoint}
 dd if=${root_mountpoint}/boot/grub/i386-pc/boot.img of=${root_disk} bs=446 count=1 conv=fsync
 udevadm settle
 dd if=${root_mountpoint}/boot/grub/i386-pc/core.img of=${root_disk} bs=512 seek=1 conv=fsync

--- a/eos-repartition-mbr
+++ b/eos-repartition-mbr
@@ -100,13 +100,3 @@ dd if=/dev/zero of=${root_disk} conv=fsync bs=512 count=1 seek=1
 udevadm settle
 dd if=/dev/zero of=${root_disk} conv=fsync bs=512 count=1 seek=${backup_gpt_offset}
 udevadm settle
-
-# Restore bootloader
-root_mountpoint=$(mktemp -d)
-mount "${root_part_base}$((root_partno - 1))" ${root_mountpoint}
-dd if=${root_mountpoint}/boot/grub/i386-pc/boot.img of=${root_disk} bs=446 count=1 conv=fsync
-udevadm settle
-dd if=${root_mountpoint}/boot/grub/i386-pc/core.img of=${root_disk} bs=512 seek=1 conv=fsync
-udevadm settle
-umount ${root_mountpoint}
-rmdir ${root_mountpoint}

--- a/eos-repartition-mbr
+++ b/eos-repartition-mbr
@@ -1,5 +1,5 @@
 #!/bin/bash -e
-# Copyright (C) 2016 Endless Mobile, Inc.
+# Copyright (C) 2016-2017 Endless Mobile, Inc.
 # Licensed under the GPLv2
 
 # arguments checking

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -9,5 +9,6 @@ EXTRA_DIST = \
 	test_image_boot.py \
 	test_live_boot_generator.py \
 	test_repartition.py \
+	test_repartition_mbr.py \
 	util.py \
 	$(NULL)

--- a/tests/test_repartition_mbr.py
+++ b/tests/test_repartition_mbr.py
@@ -1,0 +1,165 @@
+#!/usr/bin/env python3
+'''
+Tests eos-repartition-mbr. Must be run as a user privileged enough to run
+`losetup`. If run as an unprivileged user, all tests are skipped.
+'''
+from contextlib import contextmanager
+import os
+import re
+from subprocess import check_call, check_output, CalledProcessError
+import tempfile
+
+from .util import (
+    BaseTestCase,
+    system_script,
+    losetup,
+    needs_root,
+    sfdisk,
+)
+
+
+EOS_REPARTITION_MBR = system_script('eos-repartition-mbr')
+SECTOR = 512
+# Dummy bootloaders
+MBR = b'x' * 440
+BIOS_BOOT_OFFSET = 129024 * SECTOR
+BIOS_BOOT = b'y' * (2014 * SECTOR)
+DISK_SIZE_BYTES = 21 * (1024 ** 3)
+STANDARD_PARTITION_TABLE = '''
+label: gpt
+unit: sectors
+
+start=        2048, size=      126976, type=C12A7328-F81F-11D2-BA4B-00A0C93EC93B
+start=      129024, size=        2048, type=21686148-6449-6E6F-744E-656564454649
+start=      131072, size=    42762240, type=4F68BCE3-E8CD-4DB1-96E7-FBCAF984B709, attrs=GUID:55
+'''.strip().encode('ascii')  # noqa: E501
+
+
+def check_bootloader(img):
+    img.seek(0)
+    assert img.read(len(MBR)) == MBR
+
+    img.seek(BIOS_BOOT_OFFSET)
+    assert img.read(len(BIOS_BOOT)) == BIOS_BOOT
+
+
+def check_gpts(img, expected):
+    n = len(expected)
+
+    img.seek(SECTOR)
+    assert img.read(n) == expected
+
+    img.seek(-SECTOR, os.SEEK_END)
+    assert img.read(n) == expected
+
+
+@contextmanager
+def _prepare(initial_table):
+    with tempfile.NamedTemporaryFile(buffering=0) as img:
+        img.write(MBR)
+
+        img.seek(BIOS_BOOT_OFFSET)
+        img.write(BIOS_BOOT)
+
+        img.truncate(DISK_SIZE_BYTES)
+
+        sfdisk(img.name, initial_table)
+
+        # Double-check that the image looks right before we start
+        check_bootloader(img)
+        check_gpts(img, b'EFI PART')
+
+        with losetup(img.name) as img_device:
+            yield img, img_device
+
+
+class TestRepartitionMbr(BaseTestCase):
+    @needs_root
+    def test_repartition_mbr(self):
+        with _prepare(STANDARD_PARTITION_TABLE) as (img, img_device):
+            try:
+                check_call([EOS_REPARTITION_MBR, img_device])
+
+                new_table = check_output(["sfdisk", "--dump", img_device],
+                                         universal_newlines=True)
+                # Normalize the one bit that varies
+                new_table = re.sub(r'^label-id: 0x[0-9a-f]{8}$',
+                                   '''label-id: 0xdeadbeef''',
+                                   new_table,
+                                   flags=re.MULTILINE)
+
+                expected_table = '''
+label: dos
+label-id: 0xdeadbeef
+device: {img_device}
+unit: sectors
+
+{img_device}p1 : start=        2048, size=      126976, type=ef
+{img_device}p2 : start=      131072, size=    42762240, type=83, bootable
+{img_device}p4 : start=           0, size=           0, type=dd
+                    '''.strip().format(img_device=img_device).split('\n')
+
+                assert expected_table == new_table.strip().split('\n')
+
+                # BIOS bootloaders should be intact
+                check_bootloader(img)
+
+                # GPTs should be erased
+                check_gpts(img, b'\0' * SECTOR)
+            except:
+                # Log the current state to aid debugging
+                check_call(["sfdisk", "--dump", img_device])
+                raise
+
+    @needs_root
+    def test_fails_if_esp_missing(self):
+        self._test_missing(0)
+
+    @needs_root
+    def test_fails_if_bios_boot_missing(self):
+        self._test_missing(1)
+
+    @needs_root
+    def test_fails_if_root_missing(self):
+        self._test_missing(2)
+
+    def _test_missing(self, index):
+        lines = STANDARD_PARTITION_TABLE.split(b'\n')
+        i = index + 3
+        initial_table = b'\n'.join(lines[:i] + lines[i+1:])
+
+        self._test_fails(initial_table)
+
+    @needs_root
+    def test_fails_with_swap_partition(self):
+        initial_table = STANDARD_PARTITION_TABLE + b'''
+start=    42893312, size=     1024000, type=0657FD6D-A4AB-43C4-84E5-0933C84B4F4F'''  # noqa: E501
+
+        self._test_fails(initial_table)
+
+    @needs_root
+    def test_fails_with_unknown_partition(self):
+        # type= is a fresh UUID generated for this test
+        initial_table = STANDARD_PARTITION_TABLE + b'''
+start=    42893312, size=     1024000, type=18B660C0-CAB5-4990-8898-07169F986163'''  # noqa: E501
+
+        self._test_fails(initial_table)
+
+    def _test_fails(self, initial_table):
+        with _prepare(initial_table) as (img, img_device):
+            # Read back the partition table. This includes extra fields like
+            # 'label-id' and the device path, both of which vary between runs.
+            # It's easier to do this than to try to post-process new_table to
+            # make it match initial_table.
+            written_table = check_output(["sfdisk", "--dump", img_device],
+                                         universal_newlines=True)
+
+            with self.assertRaises(CalledProcessError):
+                check_call([EOS_REPARTITION_MBR, img_device])
+
+            # Check nothing was modified
+            new_table = check_output(["sfdisk", "--dump", img_device],
+                                     universal_newlines=True)
+            assert written_table.split('\n') == new_table.split('\n')
+            check_bootloader(img)
+            check_gpts(img, b'EFI PART')


### PR DESCRIPTION
Previously, we removed it from the partition table. But in practice it is relatively common for users (and Endless developers!) to boot from USB stick in legacy mode, which causes eos-installer to run this script after writing the image to disk, then attempt to boot the installed system in UEFI mode.

Instead, we preserve the ESP, using the 'EF' partition type.  This is the same partition type we and others use in our MBR-only hybrid .iso images, so it's expected that the majority of UEFI systems will be able to boot it.  (eos-installer still prefers to leave the disk in GPT format if it know the system is UEFI.)

We also leave the BIOS bootloader where it is (in the now-unpartitioned space between the ESP and the ostree partition) rather than reinstalling it at the start of the disk. See commit message for rationale. I think it was only me who wanted the previous behaviour in the first place! We could instead use some other partition type code for this partition. None of the defined codes seem particularly suitable, though.

I also cleaned up some warnings, and added some tests.

https://phabricator.endlessm.com/T20245