### PR TITLE
remove 'gnome' remote and migrate runtimes

### DIFF
--- a/eos-update-flatpak-repos
+++ b/eos-update-flatpak-repos
@@ -428,12 +428,15 @@ def _migrate_installed_flatpaks():
                                      subpaths=old_subpaths)
 
         # also search for name.* runtimes to migrate to catch extensions
-        if not prefix:
-            prefix = name + '.'
-        matching_refs += _filter_refs(refs, prefix=prefix,
-                                      kind=Flatpak.RefKind.RUNTIME,
-                                      branch=old_branch, origin=old_origin,
-                                      subpaths=old_subpaths)
+        # unless we are already searching runtimes by prefix - in this case
+        # we will already have found the matching extensions
+        if name or kind == Flatpak.RefKind.APP:
+            if not prefix:
+                prefix = name + '.'
+            matching_refs += _filter_refs(refs, prefix=prefix,
+                                          kind=Flatpak.RefKind.RUNTIME,
+                                          branch=old_branch, origin=old_origin,
+                                          subpaths=old_subpaths)
 
         if len(matching_refs) == 0:
             logging.debug('Found no matches to migrate for {}'.format(name))

--- a/eos-update-flatpak-repos
+++ b/eos-update-flatpak-repos
@@ -95,7 +95,9 @@ REMOTES_TO_REMOVE = [
     # legacy eos-external-apps local repo (T14442)
     'eos-external-apps',
     # legacy gnome-apps repo (T19898)
-    'gnome-apps'
+    'gnome-apps',
+    # legacy gnome runtimes repo (T20443)
+    'gnome'
 ]
 
 
@@ -276,6 +278,28 @@ FLATPAKS_TO_MIGRATE = [
         'old-branch': 'eos3',
         'new-branch': 'stable',
         'old-origin': 'eos-apps',
+        'new-origin': 'flathub'
+    },
+    # migrate gnome 3.2[46] and freedesktop 1.6 runtimes to flathub (T20443)
+    {
+        'prefix': 'org.freedesktop.',
+        'kind': Flatpak.RefKind.RUNTIME,
+        'old-branch': '1.6',
+        'old-origin': 'gnome',
+        'new-origin': 'flathub'
+    },
+    {
+        'prefix': 'org.gnome.',
+        'kind': Flatpak.RefKind.RUNTIME,
+        'old-branch': '3.24',
+        'old-origin': 'gnome',
+        'new-origin': 'flathub'
+    },
+    {
+        'prefix': 'org.gnome.',
+        'kind': Flatpak.RefKind.RUNTIME,
+        'old-branch': '3.26',
+        'old-origin': 'gnome',
         'new-origin': 'flathub'
     }
 ]

--- a/flatpak-repos/Makefile.am
+++ b/flatpak-repos/Makefile.am
@@ -2,6 +2,5 @@ flatpakrepodir = $(pkgdatadir)/flatpak-repos
 dist_flatpakrepo_DATA = \
 	eos-sdk.flatpakrepo \
 	flathub.flatpakrepo \
-	gnome.flatpakrepo \
 	$(NULL)
 

--- a/flatpak-repos/gnome.flatpakrepo
+++ b/flatpak-repos/gnome.flatpakrepo
@@ -1,8 +1,0 @@
-[Flatpak Repo]
-Title=Gnome Stable Runtimes
-Url=https://sdk.gnome.org/repo/
-Homepage=https://www.gnome.org/get-involved/
-Comment=The standard Gnome runtime used by most gnome apps
-Description=GNOME runtimes are released with each major release and contain the main GNOME platform libraries. At the moment they only receive minor bug fixing and security updates, but should be considered ABI stable and frozen.
-Icon=https://www.gnome.org/wp-content/themes/gnome-grass/images/gnome-logo.png
-GPGKey=mQENBFUUCGcBCAC/K9WeV4xCaKr3NKRqPXeY5mpaXAJyasLqCtrDx92WUgbu0voWrhohNAKpqizod2dvzc/XTxm3rHyIxmNfdhz1gaGhynU75Qw4aJVcly2eghTIl++gfDtOvrOZo/VuAq30f32dMIgHQdRwEpgCwz7WyjpqZYltPAEcCNL4MTChAfiHJeeiQ5ibystNBW8W6Ymf7sO4m4g5+/aOxI54oCOzD9TwBAe+yXcJJWtc2rAhMCjtyPJzxd0ZVXqIzCe1xRvJ6Rq7YCiMbiM2DQFWXKnmYQbj4TGNMnwNdAajCdrcBWEMSbzq7EzuThIJRd8Ky4BkEe1St6tuqwFaMZz+F9eXABEBAAG0KEdub21lIFNESyAzLjE2IDxnbm9tZS1vcy1saXN0QGdub21lLm9yZz6JATgEEwECACIFAlUUCGcCGwMGCwkIBwMCBhUIAgkKCwQWAgMBAh4BAheAAAoJEArkz6VV0VKBa5cH/0vXa31YgEjNk78gGFXqnQxdD1WYA87OYxDi189l4lA802EFTF4wCBuZyDOqdd5BhS3Ab0cR778DmZXRUP2gwe+1zTJypU2JMnDpkwJ4NK1VP6/tE4SAPrznBtmb76BKaWBqUfZ9Wq1zg3ugvqkZB/Exq+usypIOwQVp1KL58TrjBRda0HvRctzkNhr0qYAtkfLFe0GvksBp4vBm8uGwAx7fw/HbhIjQ9pekTwvB+5GwDPO/tSip/1bQfCS+XJB8Ffa04HYPLGedalnWBrwhYY+G/kn5Zh9L/AC8xeLwTJTHM212rBjPa9CWs9C6a57MSaeGIEHLC1hEyiJJ15w8jmY=


### PR DESCRIPTION
Remove the 'gnome' remote and migrate the fd.o 1.6 and gnome 3.2[46]
runtimes to the 'flathub' remote. Fix a small bug in attempting to migrate
prefix-matched runtimes multiple times.

https://phabricator.endlessm.com/T20443