### PR TITLE
eos-update-flatpak-repos: switch Atom to flathub

### DIFF
--- a/eos-update-flatpak-repos
+++ b/eos-update-flatpak-repos
@@ -268,6 +268,15 @@ FLATPAKS_TO_MIGRATE = [
         'new-branch': 'stable',
         'old-origin': 'eos-apps',
         'new-origin': 'flathub'
+    },
+    # migrate Atom from eos-apps to flathub (T20301)
+    {
+        'name': 'io.atom.Atom',
+        'kind': Flatpak.RefKind.APP,
+        'old-branch': 'eos3',
+        'new-branch': 'stable',
+        'old-origin': 'eos-apps',
+        'new-origin': 'flathub'
     }
 ]
 


### PR DESCRIPTION
The build on eos-apps was depending on freedesktop 1.4,
which is not available on flathub, so this is needed as
part of deprecating our need for the gnome repo.

https://phabricator.endlessm.com/T20301