### PR TITLE
Add eos-fix-external-appstream

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -19,6 +19,7 @@ dist_systemdunit_DATA = \
 	eos-extra-resize.service \
 	eos-firewall-localonly.service \
 	eos-firstboot.service \
+	eos-fix-external-appstream.service \
 	eos-fix-flatpak-branches.service \
 	eos-fix-home-dir-permissions.service \
 	eos-image-boot-dm-setup.service \
@@ -92,6 +93,7 @@ dist_sbin_SCRIPTS = \
 	eos-extra-resize \
 	eos-firewall-localonly \
 	eos-firstboot \
+	eos-fix-external-appstream \
 	eos-fix-flatpak-branches \
 	eos-fix-home-dir-permissions \
 	eos-image-boot-dm-setup \

--- a/eos-fix-external-appstream
+++ b/eos-fix-external-appstream
@@ -1,0 +1,24 @@
+#!/bin/bash -e
+
+# EOS downloads an external appstream file "eos-extra.xml" every time there's a refresh
+# and the server's file is younger than the cached one.
+#
+# We ship a version of eos-extra.xml in the images as a base point but the name used to
+# store the file no longer corresponds to the one GNOME Software generates: it should now
+# take an "org.gnome.Software-" prefix.
+#
+# This script hence attempts to remove an eventually dangling "eos-extra.xml" file.
+
+EXTERNAL_APPSTREAM_DIR=/var/cache/app-info/xmls
+OLD_EOS_EXTRA=${EXTERNAL_APPSTREAM_DIR}/eos-extra.xml.gz
+NEW_EOS_EXTRA=${EXTERNAL_APPSTREAM_DIR}/org.gnome.Software-eos-extra.xml.gz
+
+if [ -f ${OLD_EOS_EXTRA} ]; then
+    # Check if the org.gnome.Software-eos-extra.xml.gz doesn't exist yet, in which case
+    # we just rename the eos-extra.xml.gz file
+    if [ ! -f ${NEW_EOS_EXTRA} ]; then
+	mv ${OLD_EOS_EXTRA} ${NEW_EOS_EXTRA}
+    else
+	rm ${OLD_EOS_EXTRA}
+    fi
+fi

--- a/eos-fix-external-appstream.service
+++ b/eos-fix-external-appstream.service
@@ -1,0 +1,11 @@
+[Unit]
+Description=Rename or remove the outdated external appstream file
+ConditionPathExists=/var/cache/app-info/xmls/eos-extra.xml.gz
+
+[Service]
+Type=oneshot
+RemainAfterExit=yes
+ExecStart=/usr/sbin/eos-fix-external-appstream
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
EOS downloads an external appstream file "eos-extra.xml" every time
there's a refresh and the server's file is younger than the cached one.

We ship a version of eos-extra.xml in the images as a base point but the
name used to store the file no longer corresponds to the one GNOME
Software generates: it should now take an "org.gnome.Software-" prefix.

So this patch creates a service to rename or remove that file.

https://phabricator.endlessm.com/T19319