### PR TITLE
migrate remaining eos-apps to flathub where app ID matches

### DIFF
--- a/eos-update-flatpak-repos
+++ b/eos-update-flatpak-repos
@@ -301,6 +301,119 @@ FLATPAKS_TO_MIGRATE = [
         'old-branch': '3.26',
         'old-origin': 'gnome',
         'new-origin': 'flathub'
+    },
+    # migrate eos-apps to flathub where the app ID is the same (T20724)
+    {
+        'name': 'com.google.AndroidStudio',
+        'kind': Flatpak.RefKind.APP,
+        'old-branch': 'eos3',
+        'new-branch': 'stable',
+        'old-origin': 'eos-apps',
+        'new-origin': 'flathub'
+    },
+    {
+        'name': 'com.slack.Slack',
+        'kind': Flatpak.RefKind.APP,
+        'old-branch': 'eos3',
+        'new-branch': 'stable',
+        'old-origin': 'eos-apps',
+        'new-origin': 'flathub'
+    },
+    {
+        'name': 'com.spotify.Client',
+        'kind': Flatpak.RefKind.APP,
+        'old-branch': 'eos3',
+        'new-branch': 'stable',
+        'old-origin': 'eos-apps',
+        'new-origin': 'flathub'
+    },
+    {
+        'name': 'com.transmissionbt.Transmission',
+        'kind': Flatpak.RefKind.APP,
+        'old-branch': 'eos3',
+        'new-branch': 'stable',
+        'old-origin': 'eos-apps',
+        'new-origin': 'flathub'
+    },
+    {
+        'name': 'net.minetest.Minetest',
+        'kind': Flatpak.RefKind.APP,
+        'old-branch': 'eos3',
+        'new-branch': 'stable',
+        'old-origin': 'eos-apps',
+        'new-origin': 'flathub'
+    },
+    {
+        'name': 'org.freeciv.Freeciv',
+        'kind': Flatpak.RefKind.APP,
+        'old-branch': 'eos3',
+        'new-branch': 'stable',
+        'old-origin': 'eos-apps',
+        'new-origin': 'flathub'
+    },
+    {
+        'name': 'org.gnome.Builder',
+        'kind': Flatpak.RefKind.APP,
+        'old-branch': 'eos3',
+        'new-branch': 'stable',
+        'old-origin': 'eos-apps',
+        'new-origin': 'flathub'
+    },
+    {
+        'name': 'org.gnome.Genius',
+        'kind': Flatpak.RefKind.APP,
+        'old-branch': 'eos3',
+        'new-branch': 'stable',
+        'old-origin': 'eos-apps',
+        'new-origin': 'flathub'
+    },
+    {
+        'name': 'org.gnome.Gnote',
+        'kind': Flatpak.RefKind.APP,
+        'old-branch': 'eos3',
+        'new-branch': 'stable',
+        'old-origin': 'eos-apps',
+        'new-origin': 'flathub'
+    },
+    {
+        'name': 'org.inkscape.Inkscape',
+        'kind': Flatpak.RefKind.APP,
+        'old-branch': 'eos3',
+        'new-branch': 'stable',
+        'old-origin': 'eos-apps',
+        'new-origin': 'flathub'
+    },
+    {
+        'name': 'org.pitivi.Pitivi',
+        'kind': Flatpak.RefKind.APP,
+        'old-branch': 'eos3',
+        'new-branch': 'stable',
+        'old-origin': 'eos-apps',
+        'new-origin': 'flathub'
+    },
+    {
+        'name': 'org.tuxpaint.Tuxpaint',
+        'kind': Flatpak.RefKind.APP,
+        'old-branch': 'eos3',
+        'new-branch': 'stable',
+        'old-origin': 'eos-apps',
+        'new-origin': 'flathub'
+    },
+    {
+        'name': 'org.videolan.VLC',
+        'kind': Flatpak.RefKind.APP,
+        'old-branch': 'eos3',
+        'new-branch': 'stable',
+        'old-origin': 'eos-apps',
+        'new-origin': 'flathub'
+    },
+    {
+        'name': 'org.wesnoth.Wesnoth',
+        'kind': Flatpak.RefKind.APP,
+        'old-branch': 'eos3',
+        'new-branch': 'stable',
+        'old-origin': 'eos-apps',
+        'new-origin': 'flathub'
     }
 ]
 

--- a/eos-update-flatpak-repos
+++ b/eos-update-flatpak-repos
@@ -552,7 +552,12 @@ def _migrate_installed_flatpaks():
                                           subpaths=old_subpaths)
 
         if len(matching_refs) == 0:
-            logging.debug('Found no matches to migrate for {}'.format(name))
+            if name:
+                logging.debug('Found no matches to migrate for {} {}'
+                              .format(kind.value_nick, name))
+            else:
+                logging.debug('Found no matches to migrate for {} {}*'
+                              .format(kind.value_nick, prefix))
             continue
 
         for ref in matching_refs:


### PR DESCRIPTION
Move these apps from eos-apps to flathub:
 com.google.AndroidStudio
 com.slack.Slack
 com.spotify.Client
 com.transmissionbt.Transmission
 net.minetest.Minetest
 org.freeciv.Freeciv
 org.gnome.Builder
 org.gnome.Genius
 org.gnome.Gnote
 org.inkscape.Inkscape
 org.pitivi.Pitivi
 org.tuxpaint.Tuxpaint
 org.videolan.VLC
 org.wesnoth.Wesnoth

https://phabricator.endlessm.com/T20724