### PR TITLE
Enable USB mouse wakeup on Mini PC systems

### DIFF
--- a/50-usb-mouse-wakeup.rules
+++ b/50-usb-mouse-wakeup.rules
@@ -1,3 +1,3 @@
-# On desktop systems, enable USB-HID mouse devices supporting boot protocol
+# On desktop/mini pc systems, enable USB-HID mouse devices supporting boot protocol
 # as a wakeup source.
-SUBSYSTEM=="usb", ATTRS{bInterfaceClass}=="03", ATTRS{bInterfaceSubClass}=="01", ATTRS{bInterfaceProtocol}=="02", ATTR{[dmi/id]chassis_type}=="3", RUN+="/bin/sh -c 'echo enabled > /sys$env{DEVPATH}/../power/wakeup'"
+SUBSYSTEM=="usb", ATTRS{bInterfaceClass}=="03", ATTRS{bInterfaceSubClass}=="01", ATTRS{bInterfaceProtocol}=="02", ATTR{[dmi/id]chassis_type}=="3|35", RUN+="/bin/sh -c 'echo enabled > /sys$env{DEVPATH}/../power/wakeup'"


### PR DESCRIPTION
Acer Desktop team requests that the USB mouse is enabled as a wakeup
source, matching the behaviour of Windows.

To minimize impact and unwanted wakeups, we add a rule for Mini PC
chassis type.

https://phabricator.endlessm.com/T20671