### PR TITLE
T20443: fix race of eos-update-flatpak-repos with mount of extra SD card

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -31,6 +31,7 @@ dist_systemdunit_DATA = \
 	$(NULL)
 
 dist_systemdgenerator_SCRIPTS = \
+	eos-extra-target-generator \
 	eos-live-boot-generator \
 	$(NULL)
 

--- a/eos-extra-target-generator
+++ b/eos-extra-target-generator
@@ -1,0 +1,14 @@
+#!/bin/sh
+
+normal_dir="$1"
+target_unit="${1}/eos-extra-settled.target"
+
+unit="[Unit]
+Description=endless-extra SD card mounted (if expected)
+Wants=local-fs.target"
+
+if [ -L "/etc/systemd/system/local-fs.target.wants/var-endless\x2dextra.mount" ]; then
+  unit="${unit}\nRequiresMountsFor=/var/endless-extra"
+fi
+
+echo "${unit}" >"${target_unit}"

--- a/eos-fix-flatpak-branches.service
+++ b/eos-fix-flatpak-branches.service
@@ -10,6 +10,10 @@ After=local-fs.target
 Before=multi-user.target systemd-update-done.service
 ConditionNeedsUpdate=/var
 
+# Ensure that the extra disk for a split-disk system has been mounted
+Requires=eos-extra-settled.target
+After=eos-extra-settled.target
+
 [Service]
 Type=oneshot
 RemainAfterExit=true

--- a/eos-update-flatpak-repos.service
+++ b/eos-update-flatpak-repos.service
@@ -17,7 +17,8 @@ ConditionNeedsUpdate=|/var
 After=eos-ostree-remotes-config.service
 
 # Ensure that the extra disk for a split-disk system has been mounted
-After=var-endless_x2dextra.mount
+Requires=eos-extra-settled.target
+After=eos-extra-settled.target
 
 [Service]
 Type=oneshot

--- a/eos-update-flatpak-repos.service
+++ b/eos-update-flatpak-repos.service
@@ -16,6 +16,10 @@ ConditionNeedsUpdate=|/var
 # Wait until the core.add-remotes-config-dir repo option is set
 After=eos-ostree-remotes-config.service
 
+# Avoid running concurrently with other services that manipulate
+# the exported flatpak .desktop and .service files
+After=eos-fix-flatpak-branches.service
+
 # Ensure that the extra disk for a split-disk system has been mounted
 Requires=eos-extra-settled.target
 After=eos-extra-settled.target


### PR DESCRIPTION
Introduce a new eos-extra-settled.target to address race conditions when
running eos-update-flatpak-repos on "split" systems where the default
flatpak system dir is provided by an SD card mounted at /var/endless-extra.
The problem is that (by design) the local-fs.target is not blocked by the
availability of /var/endless-extra so that systems can boot properly when
the SD card is unavailable - whether missing, damaged or corrupted - the
only symptom is the availability of the apps installed there, but the rest
of the system works OK.

If the discovery of the SD card is slow enough, or it's being resized or
fscked, the /var/endless-extra mount job isn't in the queue when the
eos-update-flatpak-repos job is evaluated, so the After= has no effect
and the job runs before /var/endless-extra is mounted, causing flatpak
to operate on /var/lib/flatpak (it selects /var/endless-extra by runtime
detection of /var/endless-extra/flatpak).

The fix is to introduce a new target whose conditions are met either
when /var/endless-extra is mounted, or if the system does not expect
to have an SD card, which is detected by checking for the link in
/etc/systemd/system/local-fs.wants created by the image builder to
enable /var/endless-extra on split systems.

The eos-update-flatpak-repos and eos-fix-flatpak-branches units are
updated to require eos-extra-settled.target. Note that this target
should never be used to do critical work on paths outside of the SD
card, because in the case the SD card is unavailable on a split system,
those would never run.

Also fixes a potential bug where eos-update-flatpak-repos could be
run concurrently with eos-fix-flatpak-branches.

https://phabricator.endlessm.com/T20443