### PR TITLE
nvidia: blacklist more Asus NVIDIA GM108 systems

### DIFF
--- a/nvidia/dmi-blacklist
+++ b/nvidia/dmi-blacklist
@@ -16,3 +16,15 @@ ASUSTeK COMPUTER INC.,X542UQ
 
 # Hangs upon S3 resume (940MX) (T18554)
 ASUSTeK COMPUTER INC.,X705UQ
+
+# Hangs upon S3 resume (T20647)
+ASUSTeK COMPUTER INC.,VivoBook S14 X441UF
+
+# Hangs upon S3 resume (T20647)
+ASUSTeK COMPUTER INC.,VivoBook S15 X510UF
+
+# Hangs upon S3 resume (T20647)
+ASUSTeK COMPUTER INC.,VivoBook 15_ASUS Laptop X542UF
+
+# Hangs upon S3 resume (T20647)
+ASUSTeK COMPUTER INC.,VivoBook 15_ASUS Laptop X540UB


### PR DESCRIPTION
These systems are also believed to have the nvidia 940MX/MX110/MX130
suspend/resume issue.

https://phabricator.endlessm.com/T20647