### PR TITLE
50-eos.preset: Disable apt-daily{,-upgrade}.timer

### DIFF
--- a/50-eos.preset
+++ b/50-eos.preset
@@ -9,6 +9,8 @@ disable systemd-resolved.service
 disable systemd-networkd-wait-online.service
 
 # Disable other unwanted units
+disable apt-daily.timer
+disable apt-daily-upgrade.timer
 disable bluetooth-init.service
 disable eos-firewall-localonly.service
 disable eos-update-server.service


### PR DESCRIPTION
On ostree systems, the associated .service units will always fail when
triggered. So, arrange for them to be disabled by default.

It is a little sad that this applies to converted systems where these
timers actually are useful. An alternative would be to add

    ConditionKernelCommandLine=!ostree

to apt-daily{,upgrade}.{timer,service} in the 'apt' package (or as
drop-ins in UNIT.d/ostree.conf files) but as discussed in
https://phabricator.endlessm.com/T18831#470667 this would impose more
maintenance overhead in future unless we were to push this change
upstream.

https://phabricator.endlessm.com/T18831