### PR TITLE
repartition: Don't use backslash in sed pattern

### DIFF
--- a/dracut/repartition/endless-repartition.sh
+++ b/dracut/repartition/endless-repartition.sh
@@ -271,7 +271,7 @@ EOF
 # for a drop-in to fix the existing BindsTo= entry (a drop-in can only
 # append another value). So we override the whole unit.
 sed -e "s:$orig_root_part:$root_part:" \
-  -e "s:$(systemd-escape $orig_root_part):$(systemd-escape $root_part):" \
+  -e "s:dev-disk-by.*.device:$(systemd-escape -p --suffix=device $root_part):" \
   /run/systemd/generator/systemd-fsck-root.service \
   > /etc/systemd/system/systemd-fsck-root.service
 


### PR DESCRIPTION
sed is not matching the sysroot device unit name when we try to update
it because it contains a backslash (\). Since we know there will be only
one device unit and it will always be identified by UUID, we can use a
regular expression to match it.

Also, lets call systemd-escape with the -p switch to make it ignore the
leading slash from the input string (not sure why this worked before)
and pass --suffix=device so it generates a full device unit name.

https://phabricator.endlessm.com/T21532