### PR TITLE
repartition: fix substitution of escaped device path in generated fsc…

### DIFF
--- a/dracut/repartition/endless-repartition.sh
+++ b/dracut/repartition/endless-repartition.sh
@@ -265,9 +265,15 @@ EOF
 
 # systemd-fsck-root can't be fixed as above, because there's no way
 # for a drop-in to fix the existing BindsTo= entry (a drop-in can only
-# append another value). So we override the whole unit.
+# append another value). So we override the whole unit, using sed for the
+# required manipulations.
+# systemd-escape will escape "-" characters using backslashes, however
+# sed ordinarily interprets backslashes as a syntax item. To avoid this,
+# we must double up the backslashes first.
+orig_root_part_escaped=$(systemd-escape -p $orig_root_part | sed -e 's:\\:\\\\:g')
+root_part_escaped=$(systemd-escape -p $root_part | sed -e 's:\\:\\\\:g')
 sed -e "s:$orig_root_part:$root_part:" \
-  -e "s:$(systemd-escape $orig_root_part):$(systemd-escape $root_part):" \
+  -e "s:$orig_root_part_escaped:$root_part_escaped:" \
   /run/systemd/generator/systemd-fsck-root.service \
   > /etc/systemd/system/systemd-fsck-root.service
 


### PR DESCRIPTION
…k unit

Current master images are entering the emergency shell on first boot,
after encountering error:
 systemd[1]: Timed out waiting for device dev-disk-by\x2duuid-dbe178d5\x2d9f74\x2d434b\x2d9995\x2d54328e247a37.device.

This corresponds to the UUID of the filesystem before we modified it.

JP found that the sed manipulation that we do on systemd-fsck-root.service
is not working as intended - neither on eos3.3 nor master. It's not clear
why this was not a problem before, and it is now.

systemd-escape needs to be instructed that it is working with a path, so
that it does not start the output with a leading "-". The -p argument
is added to fix this.

We must also consider backslashes in the output of systemd-escape,
which are used to escape "-" characters in the UUID.
sed also interprets backslashes as a part of its language, so
we must double them, so that sed treats them as literals.

https://phabricator.endlessm.com/T21532