### PR TITLE
dmi-blacklist: ASUS FX570UD & V272UN can't using nv drv

### DIFF
--- a/nvidia/dmi-blacklist
+++ b/nvidia/dmi-blacklist
@@ -5,6 +5,12 @@
 # delimiter: ,
 # Quote character: "
 
+# Hangs upon S3 resume (GTX1050M) (T21413)
+ASUSTeK COMPUTER INC.,ASUS Gaming FX570UD
+
+# Hangs upon S3 resume (MX150) (T21413)
+ASUSTeK COMPUTER INC.,Vivo AIO 27 V272UN
+
 # Hangs upon S3 resume (940MX) (T20281)
 ASUSTeK COMPUTER INC.,X555UQ
 


### PR DESCRIPTION
The NV GTX 1050M of FX570UD and NV MX150 of V272UN cannot resume back
from suspend with the normal display when use the nvidia driver (ver. 390.25).
If we ssh into the system, we can find that X takes the CPU resource almost
100%.
So, change the driver to nouveau which can solve the problem.

https://phabricator.endlessm.com/T21413