### PR TITLE
zram: Enable more aggressively

### DIFF
--- a/eos-enable-zram
+++ b/eos-enable-zram
@@ -1,31 +1,27 @@
 #!/bin/bash -e
-# Copyright (C) 2015 Endless Mobile, Inc.
+# Copyright (C) 2018 Endless Mobile, Inc.
 # Licensed under the GPLv2
 
-if [ $# -lt 1 ]; then
-	echo "Error: no size supplied" >&2
+if [ $# -lt 1 -o "$1" -lt 0 -o "$1" -gt 1 ]; then
+	echo "Error: 0 or 1 must be specified" >&2
 	exit 1
 fi
 
-if [ "${1:-0}" -lt 0 ]; then
-	echo "Error: invalid size $1" >&2
-	exit 1
-fi
-
-th_kb=$((1*1024*1024)) # 1GB
 ram_size_kb=$(awk '/MemTotal/{print $2}' /proc/meminfo)
 
-if [ "$ram_size_kb" -le "$th_kb" ]; then
-	if [ "${1:-0}" -ne 0 ]; then
-		if [ ! -e /sys/block/zram0 ]; then
-			modprobe zram
-		fi
-		echo $1M > /sys/block/zram0/disksize
-		mkswap /dev/zram0
-		swapon /dev/zram0
-	else
-		swapoff /dev/zram0
-		echo 1 > /sys/block/zram0/reset
-	fi
+# Only enable zram if swap isn't enabled
+if [ $(wc -l /proc/swaps | cut -d ' ' -f 1) == 1 ]; then
+    if [ "$1" -ne 0 ]; then
+        if [ ! -e /sys/block/zram0 ]; then
+            modprobe zram
+        fi
+        echo lz4 > /sys/block/zram0/comp_algorithm
+        echo $(($ram_size_kb * 2))K > /sys/block/zram0/disksize
+        mkswap /dev/zram0
+        swapon /dev/zram0
+    else
+        swapoff /dev/zram0
+        echo 1 > /sys/block/zram0/reset
+    fi
 fi
 

--- a/eos-enable-zram.service
+++ b/eos-enable-zram.service
@@ -1,13 +1,12 @@
 [Unit]
 Description=swap with zram
 Before=multi-user.target
-ConditionArchitecture=|arm
-ConditionArchitecture=|arm64
+After=swap.target
 
 [Service]
 Type=oneshot
 RemainAfterExit=true
-ExecStart=/usr/sbin/eos-enable-zram 200
+ExecStart=/usr/sbin/eos-enable-zram 1
 ExecStop=/usr/sbin/eos-enable-zram 0
 
 [Install]


### PR DESCRIPTION
Currently zram is only enabled for ARM systems with 1 GB of memory or
less. This commit enables zram for all architectures and all amounts of
memory, as long as disk-based swap isn't already in use. Here are some
of the reasons for the change:
- Currently, 1 GB, 2 GB, and even 4 GB systems can quickly become
unusable when the memory load is high (especially with Chrome).
- There are efforts underway to reduce memory usage and make the OOM
Killer more aggressive, but this strategy can coexist with those.
- In the testing over the last few days mostly on Weibu F3C and HKC N11C
computers, having a large amount of zram available allowed a
significantly higher workload than a small amount or none.
- On the Weibu, the performance with zram is slightly worse than
swapping to the eMMC, but avoids wear on the eMMC that might reduce its
lifespan.
- zram avoids having to use persistent storage space, which is scarce on
32 GB systems.
- In one experiment, lzo achieved a compression ratio of 4:1 and lz4
achieved a 3.4:1, but lz4 is lighter on the CPU so that's what we're
using.
- Other experiments showed a compression ratio of around 3:1 using lzo,
but that's still enough to make the CPU cost and reduced memory speed
worthwhile.
- There's little harm to enabling it on high memory systems because it's
only used when the physical memory is mostly full.
- The heuristic of twice as much zram as physical RAM was chosen because
there's an overhead cost (albeit only 0.1%), and for average compression
ratios you'll fill up the physical RAM around the same time the zram
fills up.

More testing is still needed, especially on split disk and ARM systems,
but this seems like a very effective mitigation to OOM problems that
have been widely reported for (at least) months.

https://phabricator.endlessm.com/T16228