### PR TITLE
nvidia: prevent loading on Acer Nitro N50-600

### DIFF
--- a/nvidia/dmi-blacklist
+++ b/nvidia/dmi-blacklist
@@ -5,6 +5,9 @@
 # delimiter: ,
 # Quote character: "
 
+# Occasional hang upon S3 resume (GTX1060) (T21513)
+Acer,Nitro N50-600
+
 # Hangs upon S3 resume (GTX1050M) (T21413)
 ASUSTeK COMPUTER INC.,ASUS Gaming FX570UD
 


### PR DESCRIPTION
The Acer Nitro N50-600 with GTX1060 fails to resume from S3 suspend
in approximately 1 of 5 boots.

When the hang is observed, the system remains responsive over ssh,
where you can login and see that Xorg is using 100% CPU.

Blacklist the buggy nvidia driver so that the nouveau driver is
used instead.

https://phabricator.endlessm.com/T21513