### PR TITLE
zram: switch from lz4 to default lzo

### DIFF
--- a/eos-enable-zram
+++ b/eos-enable-zram
@@ -15,7 +15,6 @@ if [ $(wc -l /proc/swaps | cut -d ' ' -f 1) == 1 ]; then
         if [ ! -e /sys/block/zram0 ]; then
             modprobe zram
         fi
-        echo lz4 > /sys/block/zram0/comp_algorithm
         echo $(($ram_size_kb * 2))K > /sys/block/zram0/disksize
         mkswap /dev/zram0
         swapon /dev/zram0


### PR DESCRIPTION
In testing we found that lz4 is not supported on ARM,
and since we did not see a significant peformance difference
between lzo and lz4 on Intel (and achieved a higher compression
ratio using lzo), and since most of our testing has been with lzo,
let's go with the default lzo at least for now.

https://phabricator.endlessm.com/T16228