### PR TITLE
Disable disk swap and enable zram for all users

### DIFF
--- a/eos-enable-zram
+++ b/eos-enable-zram
@@ -9,18 +9,16 @@ fi
 
 ram_size_kb=$(awk '/MemTotal/{print $2}' /proc/meminfo)
 
-# Only enable zram if swap isn't enabled
-if [ $(wc -l /proc/swaps | cut -d ' ' -f 1) == 1 ]; then
-    if [ "$1" -ne 0 ]; then
-        if [ ! -e /sys/block/zram0 ]; then
-            modprobe zram
-        fi
-        echo $(($ram_size_kb * 2))K > /sys/block/zram0/disksize
-        mkswap /dev/zram0
-        swapon /dev/zram0
-    else
-        swapoff /dev/zram0
-        echo 1 > /sys/block/zram0/reset
+if [ "$1" -ne 0 ]; then
+    if [ ! -e /sys/block/zram0 ]; then
+        modprobe zram
     fi
+    echo $(($ram_size_kb * 2))K > /sys/block/zram0/disksize
+    # For now, disable the swap partition if in use
+    swapoff -a
+    mkswap /dev/zram0
+    swapon /dev/zram0
+else
+    swapoff /dev/zram0
+    echo 1 > /sys/block/zram0/reset
 fi
-


### PR DESCRIPTION
Performance is significantly degraded when swapping to spinning HDDs,
and zram offers much better performance.  For now, let's disable
the swap partition at boot for all users and use zram instead.
In the future, we may consider other options such as zswap to make
more effective use of disk swapping, or combining zram with swap
(if we can ensure that zram has the higher priority), or removing
the swap partition altogether.

https://phabricator.endlessm.com/T21726