### PR TITLE
enable persistent journal on durable storage devices

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -12,6 +12,7 @@ AM_DISTCHECK_CONFIGURE_FLAGS = \
 	$(NULL)
 
 dist_systemdunit_DATA = \
+	eos-config-journal.service \
 	eos-enable-extra-upgrade.service \
 	eos-enable-zram.service \
 	eos-extra-resize.service \
@@ -77,6 +78,7 @@ dist_polkitrules_DATA = \
 	$(NULL)
 
 dist_sbin_SCRIPTS = \
+	eos-config-journal \
 	eos-enable-extra-upgrade \
 	eos-enable-zram \
 	eos-extra-resize \

--- a/eos-config-journal
+++ b/eos-config-journal
@@ -1,0 +1,34 @@
+#!/bin/bash -e
+# Copyright (C) 2018 Endless Technologies, Inc.
+# Licensed under the GPLv2
+
+# if this dir exists, the journal will be persistently stored to it
+JOURNALDIR=/var/log/journal
+parentdir=$(dirname $JOURNALDIR)
+blockerfile=$parentdir/.no_journal_on_fragile_storage
+cmdname=$(basename $0)
+
+# get the device which will hold the journal
+device=$(df --output=source $parentdir | tail -n 1)
+
+# will contain non-empty string if this device is an MMC or SD device (both of
+# which are susceptible to damage with excessive writing)
+subsystem=$(lsblk --noheading -o SUBSYSTEMS ${device} | grep '^block:mmc' \
+    || true)
+
+if [ "x$subsystem" != "x" ]; then
+    echo "$cmdname: not enabling persistent journal: non-durable storage" \
+        "(MMC or SD)"
+    touch $blockerfile
+    exit 0
+fi
+
+if [ -e $blockerfile ]; then
+    echo "$cmdname: not enabling persistent journal: $blockerfile exists"
+    exit 0
+fi
+
+if [ ! -d $JOURNALDIR ]; then
+    echo "$cmdname: enabling persistent journal on durable storage"
+    mkdir $JOURNALDIR
+fi

--- a/eos-config-journal.service
+++ b/eos-config-journal.service
@@ -1,0 +1,13 @@
+[Unit]
+Description=configure persistent journal on durable storage
+Before=multi-user.target
+ConditionPathExists=!/var/log/journal
+ConditionPathExists=!/var/log/.no_journal_on_fragile_storage
+
+[Service]
+Type=oneshot
+RemainAfterExit=true
+ExecStart=/usr/sbin/eos-config-journal
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
This is meant to allow us easier access to detailed logs by ensuring
they already exist by the time an issue has been discovered. This is
particularly important when users often change their behavior just after
enabling logging which can lead to reporting of unhelpful journals.

Specifically, we enable the persistent journal by creating
/var/log/journal if /var is on a non-{MMC,SD} device since those storage
types can be degraded with significant writing (though our configuration
rate-limits the journal's access to storage significantly).

https://phabricator.endlessm.com/T21771