### PR TITLE
eos-ostree-remotes-config.service: Run on every boot

### DIFF
--- a/eos-ostree-remotes-config.service
+++ b/eos-ostree-remotes-config.service
@@ -1,5 +1,8 @@
 [Unit]
 Description=Set /ostree/repo config option core.add-remotes-config-dir false
+
+# Even though this service doesn't need to run early, other update-only
+# services that run before sysinit.target want to run after it.
 DefaultDependencies=no
 Conflicts=shutdown.target
 Wants=local-fs.target
@@ -8,13 +11,9 @@ After=local-fs.target
 # Only needed if /ostree/repo exists
 ConditionPathIsDirectory=/ostree/repo
 
-# Only run on updates
-Before=multi-user.target systemd-update-done.service
-ConditionNeedsUpdate=|/etc
-ConditionNeedsUpdate=|/var
-
 # Try to run before any ostree clients so that they all see the updated
 # repo option
+Before=multi-user.target
 Before=eos-autoupdater.service eos-updater.service
 Before=eos-updater-avahi.service eos-update-server.service
 


### PR DESCRIPTION
Only fixing the remote configuration after an upgrade doesn't help you
if the broken remote configuration is preventing you from upgrade. Run
on every boot so that users who get into a broken configuration can
possibly fix it with a reboot.

The service still needs to have DefaultDependencies=no to support being
run before update-only services that run before sysinit.target.

https://phabricator.endlessm.com/T22258