### PR TITLE
eos-update-flatpak-repos: Add Before= and Conflicts= for eos-updater

### DIFF
--- a/eos-update-flatpak-repos.service
+++ b/eos-update-flatpak-repos.service
@@ -24,6 +24,11 @@ After=eos-fix-flatpak-branches.service
 Requires=eos-extra-settled.target
 After=eos-extra-settled.target
 
+# In lieu of proper locking, we must not run at the same time as anything
+# else which touches flatpak configuration.
+Conflicts=eos-updater.service
+Before=eos-updater-flatpak-installer.service
+
 [Service]
 Type=oneshot
 RemainAfterExit=true


### PR DESCRIPTION
Ensure that eos-update-flatpak-repos can’t be running at the same time
as eos-updater or eos-updater-flatpak-installer, since they all operate
on the same flatpak repos, and eos-update-flatpak-repos operates at a
fairly low level.

Use Conflicts=eos-updater.service because eos-updater is D-Bus
activated, and isn’t run on boot, so a Before=/After= ordering wouldn’t
make sense.

Use Before=eos-updater-flatpak-installer, since that *is* run at boot,
and would probably benefit from having the right repositories in place
before it runs.

Signed-off-by: Philip Withnall <withnall@endlessm.com>

https://phabricator.endlessm.com/T22525