### PR TITLE
eos-repartition-mbr: invoke python3, not python (2)

### DIFF
--- a/eos-repartition-mbr
+++ b/eos-repartition-mbr
@@ -72,8 +72,8 @@ udevadm settle
 # from sfdisk's output, but we can get it from the primary header:
 # https://en.wikipedia.org/wiki/GUID_Partition_Table#Partition_table_header_.28LBA_1.29
 backup_gpt_offset=$(
-  dd if="$root_disk" bs=1 count=8 skip=$(( 512 + 0x20 )) | python -c \
-    'import sys, struct; print struct.unpack("<Q", sys.stdin.read(8))[0]'
+  dd if="$root_disk" bs=1 count=8 skip=$(( 512 + 0x20 )) | python3 -c \
+    'import sys, struct; print(struct.unpack("<Q", sys.stdin.buffer.read(8))[0])'
 )
 backup_gpt="$(dd if="$root_disk" bs=512 skip="$backup_gpt_offset" count=1)"
 if [ "${backup_gpt::8}" != "EFI PART" ]; then


### PR DESCRIPTION
This package never had a dependency on python2; as a result, this script
broke when we removed the apparently-unused Python 2.7 from the OS.

In Python 2, sys.stdin.read() reads raw bytes. In Python 3, it reads
Unicode characters. Since we actually do want to read 8 raw bytes, we
read from the underlying raw stream at sys.stdin.buffer.

https://docs.python.org/3/library/sys.html#sys.stdin
https://phabricator.endlessm.com/T22665