### PR TITLE
eos-config-journal: set correct permissions on /var/log/journal

### DIFF
--- a/eos-config-journal
+++ b/eos-config-journal
@@ -2,18 +2,18 @@
 # Copyright (C) 2018 Endless Technologies, Inc.
 # Licensed under the GPLv2
 
+parentdir=/var/log
 # if this dir exists, the journal will be persistently stored to it
-JOURNALDIR=/var/log/journal
-parentdir=$(dirname $JOURNALDIR)
+JOURNALDIR=$parentdir/journal
 blockerfile=$parentdir/.no_journal_on_fragile_storage
-cmdname=$(basename $0)
+cmdname=${0##*/}
 
 # get the device which will hold the journal
 device=$(df --output=source $parentdir | tail -n 1)
 
 # will contain non-empty string if this device is an MMC or SD device (both of
 # which are susceptible to damage with excessive writing)
-subsystem=$(lsblk --noheading -o SUBSYSTEMS ${device} | grep '^block:mmc' \
+subsystem=$(lsblk --noheading -o SUBSYSTEMS "$device" | grep '^block:mmc' \
     || true)
 
 if [ "x$subsystem" != "x" ]; then

--- a/eos-config-journal
+++ b/eos-config-journal
@@ -31,4 +31,5 @@ fi
 if [ ! -d $JOURNALDIR ]; then
     echo "$cmdname: enabling persistent journal on durable storage"
     mkdir $JOURNALDIR
+    systemd-tmpfiles --create --prefix $JOURNALDIR
 fi

--- a/eos-config-journal.service
+++ b/eos-config-journal.service
@@ -3,6 +3,7 @@ Description=configure persistent journal on durable storage
 Before=multi-user.target
 ConditionPathExists=!/var/log/journal
 ConditionPathExists=!/var/log/.no_journal_on_fragile_storage
+ConditionKernelCommandLine=!endless.live_boot
 
 [Service]
 Type=oneshot


### PR DESCRIPTION
This is as suggested by `man systemd-journal`:

> On systems where /var/log/journal/ does not exist yet but where
> persistent logging is desired (and the default journald.conf is used),
> it is sufficient to create the directory, and ensure it has the
> correct access modes and ownership:

    mkdir -p /var/log/journal
    systemd-tmpfiles --create --prefix /var/log/journal

Without this, `/var/log/journal` is owned by root:root, which prevents administrators (who are members of 'adm' but not of 'root') from being able to see privileged parts of the journal without `sudo`.

An alternative approach would be to order this job before `systemd-tmpfiles-setup.service`, but there's no particular need to block the boot process on creating this directory.

I also included a fix to skip this job on live boots, and some cleanup to the job suggested by shellcheck. I tested these changes in a VM, and verified that the full journal is visible in `journalctl` run by a non-root administrator user. I do not have a device with eMMC to test that code path.

https://phabricator.endlessm.com/T22687