### PR TITLE
dracut conf: drop ext4 filesystem module

### DIFF
--- a/dracut/endless.conf
+++ b/dracut/endless.conf
@@ -1,6 +1,6 @@
 dracutmodules="dracut-systemd systemd-initrd dash drm eos-repartition eos-image-boot plymouth kernel-modules resume ostree systemd base fs-lib eos-customization"
 fscks="fsck fsck.ext4"
-filesystems="ext4 isofs"
+filesystems="isofs"
 
 # Embed microcode into ramdisk
 early_microcode="yes"


### PR DESCRIPTION
On recent ubuntu kernels, the ext4 filesystem is now built in.

Newer dracut versions will log an error if they don't find the
requested ext4 module to install in the initramfs.

  dracut-install: ERROR: installing 'ext4'
  dracut: FAILED:  /usr/lib/dracut/dracut-install -D /var/tmp/dracut.KDpSCO/initramfs -N nouveau --kerneldir /lib/modules/4.16.0-4-generic/ -m ext4 isofs

https://phabricator.endlessm.com/T22810