### PR TITLE
eos-firstboot: Change service type to simple

### DIFF
--- a/eos-firstboot.service
+++ b/eos-firstboot.service
@@ -9,7 +9,6 @@ ConditionPathExists=!/var/eos-booted
 ConditionKernelCommandLine=!endless.live_boot
 
 [Service]
-Type=oneshot
 ExecStart=/usr/sbin/eos-firstboot
 StandardOutput=journal+console
 


### PR DESCRIPTION
Service units of type oneshot delay the execution of follow-up units
until is main process exits. Since we always use ext4, the filesystem
extension can be performed on-line, so lets change this unit to simple
(the default when neither Type= nor BusName= are specified, but
ExecStart= is).

This avoids having eos-firstboot.service acting as bottleneck blocking
basic.target and the whole boot process as a consequence.

https://phabricator.endlessm.com/T22685