### PR TITLE
endless-repartition: stop creating swap partitions

### DIFF
--- a/tests/test_repartition.py
+++ b/tests/test_repartition.py
@@ -22,50 +22,10 @@ ENDLESS_REPARTITION_SH = dracut_script('repartition', 'endless-repartition.sh')
 
 class TestRepartition(BaseTestCase):
     @needs_root
-    def test_creates_swap(self):
-        '''
-        This disk is big, so we should create a swap partition at the end.
-        '''
-
-        disk_size_bytes = 256071351296
-        partition_table = '''
-label: gpt
-unit: sectors
-
-start=        2048, size=      126976, type=C12A7328-F81F-11D2-BA4B-00A0C93EC93B
-start=      129024, size=        2048, type=21686148-6449-6E6F-744E-656564454649
-start=      131072, size=       20.4G, type=4F68BCE3-E8CD-4DB1-96E7-FBCAF984B709, attrs=GUID:55
-        '''.strip().encode('utf-8')  # noqa: E501
-
-        self._go(disk_size_bytes, partition_table, swap='p4')
-
-    @needs_root
     def test_preserves_basic_data_no_swap(self):
         '''
-        This disk is too small to create a swap partition, but it does have a
-        trailing NTFS partition. It should be preserved, and not formatted as
-        swap.
-        '''
-
-        disk_size_bytes = 128035675648
-        partition_table = '''
-label: gpt
-unit: sectors
-
-start=        2048, size=      126976, type=C12A7328-F81F-11D2-BA4B-00A0C93EC93B
-start=      129024, size=        2048, type=21686148-6449-6E6F-744E-656564454649
-start=      131072, size=       20.4G, type=4F68BCE3-E8CD-4DB1-96E7-FBCAF984B709, attrs=GUID:55
-start=   232243200, size=    17825792, type=EBD0A0A2-B9E5-4433-87C0-68B6B72699C7, name="Basic data partition"
-        '''.strip().encode('utf-8')  # noqa: E501
-
-        self._go(disk_size_bytes, partition_table, bd_pre='p4', bd_post='p4')
-
-    @needs_root
-    def test_preserves_basic_data_swap(self):
-        '''
-        This disk is big, so we should create a swap partition just before the
-        trailing NTFS partition, and format the swap partition as swap -- but
-        leave the NTFS partition alone.
+        Even with larger disks we no longer create a swap partition.
+        The trailing NTFS partition should be preserved.
         '''
 
         disk_size_bytes = 256071351296
@@ -79,8 +39,30 @@ start=      131072, size=       20.4G, type=4F68BCE3-E8CD-4DB1-96E7-FBCAF984B709
 start=   482312879, size=    17825792, type=EBD0A0A2-B9E5-4433-87C0-68B6B72699C7, name="Basic data partition"
         '''.strip().encode('utf-8')  # noqa: E501
 
-        self._go(disk_size_bytes, partition_table,
-                 bd_pre='p4', bd_post='p5', swap='p4')
+        self._go(disk_size_bytes, partition_table, bd_pre='p4', bd_post='p4')
+
+    @needs_root
+    def test_preserves_basic_data_removes_swap(self):
+        '''
+        If we have a swap partition already created, we should remove it
+        and preserve the NTFS partition (with a decremented partition number).
+        Note that this requires the repartition marker (GUID:55) to be set,
+        which is normally removed after the repartitioning is complete.
+        '''
+
+        disk_size_bytes = 256071351296
+        partition_table = '''
+label: gpt
+unit: sectors
+
+start=        2048, size=      126976, type=C12A7328-F81F-11D2-BA4B-00A0C93EC93B
+start=      129024, size=        2048, type=21686148-6449-6E6F-744E-656564454649
+start=      131072, size=   473794560, type=4F68BCE3-E8CD-4DB1-96E7-FBCAF984B709, attrs=GUID:55
+start=   473925632, size=     8387247, type=0657FD6D-A4AB-43C4-84E5-0933C84B4F4F
+start=   482312879, size=    17825792, type=EBD0A0A2-B9E5-4433-87C0-68B6B72699C7, name="Basic data partition"
+        '''.strip().encode('utf-8')  # noqa: E501
+
+        self._go(disk_size_bytes, partition_table, bd_pre='p5', bd_post='p4')
 
     def _go(self, disk_size_bytes, partition_table,
             bd_pre=None, bd_post=None, swap=None):
@@ -104,8 +86,6 @@ start=   482312879, size=    17825792, type=EBD0A0A2-B9E5-4433-87C0-68B6B72699C7
                     if bd_post is not None:
                         self.assert_fstype(img_device + bd_post, 'ntfs')
 
-                    if swap is not None:
-                        self.assert_fstype(img_device + swap, 'swap')
                 except:
                     # Log the current state to aid debugging
                     check_call(["sfdisk", "--dump", img_device])


### PR DESCRIPTION
Overall, we achieve better results with zram than with disk
swap partitions, so we are no longer going to create a swap
partition on first boot.

For existing installations, if we already created the swap partition,
we currently don't do anything to remove it, so for now we need to
continue to explicitly disable the swap partition when we enable zram.

In the future we may want to automatically remove such a partition
to reclaim disk space.

https://phabricator.endlessm.com/T21758