### PR TITLE
eos-repartition-mbr: read exactly 8 bytes of backup GPT

### DIFF
--- a/eos-repartition-mbr
+++ b/eos-repartition-mbr
@@ -75,8 +75,8 @@ backup_gpt_offset=$(
   dd if="$root_disk" bs=1 count=8 skip=$(( 512 + 0x20 )) | python3 -c \
     'import sys, struct; print(struct.unpack("<Q", sys.stdin.buffer.read(8))[0])'
 )
-backup_gpt="$(dd if="$root_disk" bs=512 skip="$backup_gpt_offset" count=1)"
-if [ "${backup_gpt::8}" != "EFI PART" ]; then
+backup_gpt="$(dd if="$root_disk" bs=512 skip="$backup_gpt_offset" count=8 iflag=count_bytes)"
+if [ "${backup_gpt}" != "EFI PART" ]; then
   echo "$0: couldn't find backup GPT header at ${backup_gpt_offset}" >&2
   exit 1
 fi


### PR DESCRIPTION
Previously we would see the following warning on a successful run:

> eos-repartition-mbr: line 78: warning: command substitution: ignored null byte in input

This was because we read a full 512-byte sector at the start of where we
thought the GPT should be, and that sector would contain null bytes. But
we are only interested in 8 bytes which we expect to be the string "EFI
PART". We can avoid this warning by telling dd to read exactly 8 bytes.