### PR TITLE
eos-repartition-mbr: don't try to zero GPT headers

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -27,5 +27,6 @@ Depends: ${misc:Depends},
          python3,
          python3-gi,
          python3-systemd,
+         util-linux (>= 2.30.0),
 Breaks: systemd (<= 232+dev145.a41a4e3-23)
 Replaces: systemd (<= 232+dev145.a41a4e3-23)

--- a/eos-repartition-mbr
+++ b/eos-repartition-mbr
@@ -67,20 +67,3 @@ udevadm settle
 # disk on first boot
 printf "\xdd" | dd of="$root_disk" bs=1 count=1 seek=498 conv=notrunc
 udevadm settle
-
-# Remove GPT headers. It's a little tricky to work out where the backup one is
-# from sfdisk's output, but we can get it from the primary header:
-# https://en.wikipedia.org/wiki/GUID_Partition_Table#Partition_table_header_.28LBA_1.29
-backup_gpt_offset=$(
-  dd if="$root_disk" bs=1 count=8 skip=$(( 512 + 0x20 )) | python3 -c \
-    'import sys, struct; print(struct.unpack("<Q", sys.stdin.buffer.read(8))[0])'
-)
-backup_gpt="$(dd if="$root_disk" bs=512 skip="$backup_gpt_offset" count=8 iflag=count_bytes)"
-if [ "${backup_gpt}" != "EFI PART" ]; then
-  echo "$0: couldn't find backup GPT header at ${backup_gpt_offset}" >&2
-  exit 1
-fi
-dd if=/dev/zero of="$root_disk" conv=fsync bs=512 count=1 seek=1
-udevadm settle
-dd if=/dev/zero of="$root_disk" conv=fsync bs=512 count=1 seek="$backup_gpt_offset"
-udevadm settle

--- a/tests/test_repartition_mbr.py
+++ b/tests/test_repartition_mbr.py
@@ -105,7 +105,7 @@ unit: sectors
                 check_bootloader(img)
 
                 # GPTs should be erased
-                check_gpts(img, b'\0' * SECTOR)
+                check_gpts(img, b'\0' * len(b'EFI PART'))
             except:
                 # Log the current state to aid debugging
                 check_call(["sfdisk", "--dump", img_device])


### PR DESCRIPTION
sfdisk now does this automatically, since https://github.com/karelzak/util-linux/commit/5635d19:

> always (except --wipe=never) wipe old partition tables

with the nuance that it only wipes the "EFI PART" bytes of the table, not the whole sector, which is fine. So:

* adjust the test accordingly
* drop our logic to try to do the same thing (which fails if sfdisk has this behaviour, because the EFI PART in the backup GPT is zeroed)
* add a versioned dependency on util-linux

I do not understand how https://phabricator.endlessm.com/T22665 worked when I QAed it since we have a new-enough sfdisk in eos3.4. We should backport this change for 3.4.2.