### PR TITLE
T22763: clear up / avoid old refs for flatpaks which have been migrated

### DIFF
--- a/eos-update-flatpak-repos
+++ b/eos-update-flatpak-repos
@@ -23,6 +23,7 @@
 # along with this program; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
+import fnmatch
 import glob
 import logging
 import os
@@ -33,8 +34,8 @@ from systemd import journal
 
 import gi
 gi.require_version('Flatpak', '1.0')
-from gi.repository import Flatpak
-from gi.repository import GLib
+gi.require_version('OSTree', '1.0')
+from gi.repository import Flatpak, Gio, GLib, OSTree
 
 
 def _flatpak_inst_get_remote(inst, name):
@@ -447,6 +448,16 @@ def _filter_refs(refs, name=None, prefix=None, kind=None, arch=None,
     return ret
 
 
+def _filter_ostree_refs(refs, kind, name='*', prefix=None, arch='*',
+                        branch='*', origin='*'):
+    if prefix:
+        name = '{}*'.format(prefix)
+
+    pattern = '{}:{}/{}/{}/{}'.format(origin, kind.value_nick, name, arch, branch)
+
+    return fnmatch.filter(refs, pattern)
+
+
 def _replace_in_file(path, old, new):
     _, data = GLib.file_get_contents(path)
     assert data
@@ -533,8 +544,14 @@ def _refresh_ref(inst, kind, name, arch, branch):
 def _migrate_installed_flatpaks():
     insts = Flatpak.get_system_installations()
     inst = insts[0]
-
     refs = inst.list_installed_refs()
+
+    # we need to also operate directly on the ostree refs that shadow each
+    # flatpak so we don't leave behind local refs to the old origin and branch.
+    repo = OSTree.Repo.new(inst.get_path().get_child('repo'))
+    repo.open()
+    _, ostree_refs = repo.list_refs() # dictionary of ref -> commit
+
     for migrate in FLATPAKS_TO_MIGRATE:
         kind = migrate['kind']
         name = migrate.get('name')
@@ -545,9 +562,21 @@ def _migrate_installed_flatpaks():
         old_origin = migrate.get('old-origin')
         old_subpaths = migrate.get('old-subpaths')
 
+        # we build what should be the same list twice - from the flatpak
+        # perspective by examining the installation and deployed apps, and from
+        # the ostree perspective by examining the refs in the repo. ordinarily
+        # we would only see them differ due to a bug in previous versions of
+        # this script where the refs were not renamed during a migration.
+        # everything in the matching_ostree_refs list will be copied to its
+        # new name if we change (or previously changed) the branch or origin,
+        # and then deleted after the deployed apps are updated. (T22763)
         matching_refs = _filter_refs(refs, name=name, prefix=prefix, kind=kind,
                                      branch=old_branch, origin=old_origin,
                                      subpaths=old_subpaths)
+        matching_ostree_refs = _filter_ostree_refs(ostree_refs.keys(), kind,
+                                                   name=name, prefix=prefix,
+                                                   branch=old_branch,
+                                                   origin=old_origin)
 
         # also search for name.* runtimes to migrate to catch extensions
         # unless we are already searching runtimes by prefix - in this case
@@ -560,6 +589,12 @@ def _migrate_installed_flatpaks():
                                           branch=old_branch, origin=old_origin,
                                           subpaths=old_subpaths)
 
+            matching_ostree_refs += _filter_ostree_refs(ostree_refs.keys(),
+                                                        Flatpak.RefKind.RUNTIME,
+                                                        prefix=prefix,
+                                                        branch=old_branch,
+                                                        origin=old_origin)
+
         if len(matching_refs) == 0:
             if name:
                 logging.debug('Found no matches to migrate for {} {}'
@@ -567,7 +602,6 @@ def _migrate_installed_flatpaks():
             else:
                 logging.debug('Found no matches to migrate for {} {}*'
                               .format(kind.value_nick, prefix))
-            continue
 
         for ref in matching_refs:
             name = ref.get_name()
@@ -575,6 +609,8 @@ def _migrate_installed_flatpaks():
             branch = ref.get_branch()
             logging.info('Found {}/{}/{} to migrate'
                          .format(name, arch, branch))
+
+            old_ostree_ref = '{}:{}'.format(ref.get_origin(), ref.format_ref())
 
             try:
                 new_branch = migrate.get('new-branch')
@@ -597,9 +633,48 @@ def _migrate_installed_flatpaks():
                     _update_deploy_file_with_subpaths(deploy, new_subpaths)
                     subpaths = new_subpaths
                     ref = _refresh_ref(inst, kind, name, arch, branch)
+
+                new_ostree_ref = '{}:{}'.format(ref.get_origin(), ref.format_ref())
+
+                # in the case we have only modified the subpaths, the ref does
+                # not change, so we should remove it from the list of old refs
+                # which will be deleted.
+                if new_ostree_ref == old_ostree_ref:
+                    logging.debug('OSTree ref {} unchanged'
+                                  .format(old_ostree_ref))
+                    matching_ostree_refs.remove(old_ostree_ref)
+                    continue
+
+                # when the branch or origin has changed, we copy the old ref to
+                # the new one, pointing at the same commit
+                if old_ostree_ref in ostree_refs and \
+                   not new_ostree_ref in ostree_refs:
+                    logging.info('Copying OSTree ref {} [{}] to {}'
+                                 .format(old_ostree_ref,
+                                         ostree_refs[old_ostree_ref],
+                                         new_ostree_ref))
+                    repo.set_ref_immediate(ref.get_origin(), ref.format_ref(),
+                                           ostree_refs[old_ostree_ref])
+                    ostree_refs[new_ostree_ref] = ostree_refs[old_ostree_ref]
+
             except Exception:
                 logging.exception('Failure applying migration to {}'
                                   .format(name))
+                continue
+
+        # any refs we copied, along with any matches for apps we migrated
+        # in the past, should be deleted.
+        for old_ostree_ref in matching_ostree_refs:
+            try:
+                logging.info('Deleting old/stale OSTree ref {} [{}]'
+                             .format(old_ostree_ref,
+                                     ostree_refs[old_ostree_ref]))
+                repo.set_ref_immediate(old_ostree_ref.split(':')[0],
+                                       old_ostree_ref.split(':')[1],
+                                       None)
+            except Exception:
+                logging.exception('Failure deleting ref {}'
+                                  .format(old_ostree_ref))
                 continue
 
 

--- a/eos-update-flatpak-repos
+++ b/eos-update-flatpak-repos
@@ -23,6 +23,7 @@
 # along with this program; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
+import argparse
 import fnmatch
 import glob
 import logging
@@ -682,6 +683,13 @@ if __name__ == '__main__':
     # Send logging messages both to the console and the journal
     logging.basicConfig(level=logging.INFO)
     logging.root.addHandler(journal.JournalHandler())
+
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--debug', '-d', dest='debug', action='store_true')
+    parsed_args, otherargs = parser.parse_known_args()
+
+    if parsed_args.debug:
+        logging.root.setLevel(logging.DEBUG)
 
     # ensure default remotes exist, such as eos-sdk and flathub
     _add_flatpak_repos()

--- a/eos-update-flatpak-repos
+++ b/eos-update-flatpak-repos
@@ -524,8 +524,10 @@ def _update_branch(ref, new_branch, refs):
     # however: this is a startup job
     shutil.rmtree(old_branch_dir, ignore_errors=True)
 
-    ref.set_property("branch", new_branch)
-    ref.set_property("deploy-dir", new_deploy_dir)
+
+def _refresh_ref(inst, kind, name, arch, branch):
+    inst.drop_caches()
+    return inst.get_installed_ref(kind, name, arch, branch)
 
 
 def _migrate_installed_flatpaks():
@@ -578,6 +580,8 @@ def _migrate_installed_flatpaks():
                 new_branch = migrate.get('new-branch')
                 if new_branch:
                     _update_branch(ref, new_branch, refs)
+                    branch = new_branch
+                    ref = _refresh_ref(inst, kind, name, arch, branch)
 
                 deploy_dir = ref.get_deploy_dir()
                 deploy = os.path.join(deploy_dir, 'deploy')
@@ -585,10 +589,14 @@ def _migrate_installed_flatpaks():
                 new_origin = migrate.get('new-origin')
                 if new_origin:
                     _update_deploy_file_with_origin(deploy, new_origin)
+                    origin = new_origin
+                    ref = _refresh_ref(inst, kind, name, arch, branch)
 
                 new_subpaths = migrate.get('new-subpaths')
                 if new_subpaths:
                     _update_deploy_file_with_subpaths(deploy, new_subpaths)
+                    subpaths = new_subpaths
+                    ref = _refresh_ref(inst, kind, name, arch, branch)
             except Exception:
                 logging.exception('Failure applying migration to {}'
                                   .format(name))

--- a/eos-update-flatpak-repos
+++ b/eos-update-flatpak-repos
@@ -219,12 +219,14 @@ FLATPAKS_TO_MIGRATE = [
     {
         'name': 'com.endlessm.apps.Platform.Locale',
         'kind': Flatpak.RefKind.RUNTIME,
+        'old-origin': 'eos-sdk',
         'old-subpaths': ['/en,id,th,vi'],
         'new-subpaths': ['/en', '/id', '/th', '/vi']
     },
     {
         'name': 'com.endlessm.apps.Sdk.Locale',
         'kind': Flatpak.RefKind.RUNTIME,
+        'old-origin': 'eos-sdk',
         'old-subpaths': ['/en,id,th,vi'],
         'new-subpaths': ['/en', '/id', '/th', '/vi']
     },
@@ -449,8 +451,11 @@ def _filter_refs(refs, name=None, prefix=None, kind=None, arch=None,
     return ret
 
 
-def _filter_ostree_refs(refs, kind, name='*', prefix=None, arch='*',
-                        branch='*', origin='*'):
+def _filter_ostree_refs(refs, origin, kind, name='*', prefix=None, arch='*',
+                        branch='*'):
+    assert origin
+    assert kind.value_nick in {'app', 'runtime'}
+
     if prefix:
         name = '{}*'.format(prefix)
 
@@ -555,12 +560,13 @@ def _migrate_installed_flatpaks():
 
     for migrate in FLATPAKS_TO_MIGRATE:
         kind = migrate['kind']
+        old_origin = migrate['old-origin']
+
         name = migrate.get('name')
         prefix = migrate.get('prefix')
         assert name or prefix
 
         old_branch = migrate.get('old-branch')
-        old_origin = migrate.get('old-origin')
         old_subpaths = migrate.get('old-subpaths')
 
         # we build what should be the same list twice - from the flatpak
@@ -574,10 +580,10 @@ def _migrate_installed_flatpaks():
         matching_refs = _filter_refs(refs, name=name, prefix=prefix, kind=kind,
                                      branch=old_branch, origin=old_origin,
                                      subpaths=old_subpaths)
-        matching_ostree_refs = _filter_ostree_refs(ostree_refs.keys(), kind,
+        matching_ostree_refs = _filter_ostree_refs(ostree_refs.keys(),
+                                                   old_origin, kind,
                                                    name=name, prefix=prefix,
-                                                   branch=old_branch,
-                                                   origin=old_origin)
+                                                   branch=old_branch)
 
         # also search for name.* runtimes to migrate to catch extensions
         # unless we are already searching runtimes by prefix - in this case
@@ -591,10 +597,10 @@ def _migrate_installed_flatpaks():
                                           subpaths=old_subpaths)
 
             matching_ostree_refs += _filter_ostree_refs(ostree_refs.keys(),
+                                                        old_origin,
                                                         Flatpak.RefKind.RUNTIME,
                                                         prefix=prefix,
-                                                        branch=old_branch,
-                                                        origin=old_origin)
+                                                        branch=old_branch)
 
         if len(matching_refs) == 0:
             if name:


### PR DESCRIPTION
Previous versions of eos-update-flatpak-repos left behind local ostree refs to the old origin/branch of the apps it had migrated. This meant that once flatpak had upgraded the app and pulled the new ref from the network, the old one was never cleaned up, leaving behind the commit and disk space associated with the old version of the app.

To both fix this problem, and prevent it happening again, we build a list of matching ostree refs which should shadow the installed flatpaks we are migrating, and copy the ref to the new name if the app branch or origin is changed during the migration. The remaining refs in our list at the end of the process have either just been migrated, or were migrated in the past, and are therefore deleted.

https://phabricator.endlessm.com/T22763