### PR TITLE
dmi-blacklist: Acer Predator Orion 5-100 can't use nv drv

### DIFF
--- a/nvidia/dmi-blacklist
+++ b/nvidia/dmi-blacklist
@@ -8,6 +8,9 @@
 # Occasional hang upon S3 resume (GTX1060) (T21513)
 Acer,Nitro N50-600
 
+# Hang upon S3 resume on first boot (GTX1050Ti) (T21605)
+Acer,Predator Orion 5-100
+
 # Hangs upon S3 resume (GTX1050M) (T21413)
 ASUSTeK COMPUTER INC.,ASUS Gaming FX570UD
 


### PR DESCRIPTION
The NV GTX 1050 Ti of Predator Orion 5-100 cannot resume back from
suspend on first boot with the normal display when use the nvidia driver
(ver. 390.48).  If we ssh into the system, we can find that X takes the
CPU resource almost 100%.

So, change the driver to nouveau which can solve the problem.

https://phabricator.endlessm.com/T21605

Signed-off-by: Jian-Hong Pan <jian-hong@endlessm.com>