### PR TITLE
Configure zRAM to be 150% of the physical RAM memory's size

### DIFF
--- a/eos-enable-zram
+++ b/eos-enable-zram
@@ -13,7 +13,7 @@ if [ "$1" -ne 0 ]; then
     if [ ! -e /sys/block/zram0 ]; then
         modprobe zram
     fi
-    echo $(($ram_size_kb * 2))K > /sys/block/zram0/disksize
+    echo $(($ram_size_kb * 3 / 2))K > /sys/block/zram0/disksize
     # For now, disable the swap partition if in use
     swapoff -a
     mkswap /dev/zram0


### PR DESCRIPTION
Swapped pages to zRAM occupies space in the physical RAM (in its compressed
state), so having a too big zRAM-backed swap partition can actually impact
performance in a negative way, since a big chunk of RAM would be used if
all swap is occupied. For instance, for a system with 2GB of RAM and 4GB
of zRAM with a typical compressed ratio between 3:1 and 4:1, this would
mean that as much as 1GB - 1.3GB of RAM could be used for zRAM, leaving
a bare amount of 700MB - 1GB left as uncompressed physical memory.

Based on some discussions found online with suggestions about how to setup
zRAM for ChromiumOS devices [1], and also on an actual configuration file
confirming such suggestions [2], I'm changing the configuration of zRAM
to match that policy of `zRAM_size = RAM_size * 1.5`, in an attempt to
improve performance of our low memory devices.

[1] https://productforums.google.com/forum/#!topic/chromebook-central/HmfWTDyBITk
[2] https://chromium.googlesource.com/chromiumos/platform/init/+/factory-3536.B/swap.conf

https://phabricator.endlessm.com/T23137