### PR TITLE
nvidia: support blacklisting nouveau module too

### DIFF
--- a/nvidia/nvidia-graphics-setup
+++ b/nvidia/nvidia-graphics-setup
@@ -189,5 +189,5 @@ fi
 
 # nouveau claims all devices based on the nvidia vendor IDs so we don't
 # need to do a specific product ID lookup here, just load it.
-echo "Loading nouveau"
-modprobe nouveau
+echo "Loading nouveau (if not blacklisted)"
+modprobe --use-blacklist nouveau


### PR DESCRIPTION
On some hardware models (Dell XPS 15) this crashes the kernel, so
support blacklisting it.

https://phabricator.endlessm.com/T23272