### PR TITLE
dmi-board-blacklist: No Endless logo shown during boot on Nitro N50-100

### DIFF
--- a/nvidia/dmi-blacklist
+++ b/nvidia/dmi-blacklist
@@ -5,6 +5,9 @@
 # delimiter: ,
 # Quote character: "
 
+# No Endless logo during boot (GTX1050Ti) (T23367)
+Acer,Nitro N50-100
+
 # Occasional hang upon S3 resume (GTX1060) (T21513)
 Acer,Nitro N50-600
 


### PR DESCRIPTION
There is no Endless logo shown during boot on Acer Nitro N50-100.
Blacklisting the nvidia driver and using nouveau fix this issue.

https://phabricator.endlessm.com/T23367

Signed-off-by: Jian-Hong Pan <jian-hong@endlessm.com>