### PR TITLE
eos-update-flatpak-repos: remove OSTree leaked refs for eos3

### DIFF
--- a/eos-update-flatpak-repos
+++ b/eos-update-flatpak-repos
@@ -81,6 +81,29 @@ def _add_flatpak_repos():
                                '--from', name, repo_file])
 
 
+# list of ostree refs
+OSTREE_REFS_TO_REMOVE = [
+    # remove eos3.3 refs leaked by eos-updater checkpoint bug (T23410)
+    'eos:os/eos/amd64/eos3',
+    'eos:os/eos/ec100/eos3',
+    'eos:os/eos/nexthw/eos3'
+]
+
+
+def _remove_ostree_refs():
+    try:
+        repo = OSTree.Repo.new_default()
+        repo.open()
+        _, ostree_refs = repo.list_refs() # dictionary of ref -> commit
+        for ref in OSTREE_REFS_TO_REMOVE:
+            if ref in ostree_refs:
+                logging.info('Deleting leaked OSTree ref {}'.format(ref))
+                repo.set_ref_immediate(ref.split(':')[0], ref.split(':')[1],
+                                       None)
+    except Exception:
+        logging.exception('Failure deleting leaked OSTree refs')
+
+
 # list of remote names
 REMOTES_TO_REMOVE = [
 ]
@@ -667,7 +690,8 @@ if __name__ == '__main__':
     # ensure default remotes exist, such as eos-sdk and flathub
     _add_flatpak_repos()
 
-    # remove any unused remotes and runtimes
+    # remove any unused refs, remotes and runtimes
+    _remove_ostree_refs()
     _remove_remotes()
     _remove_runtimes()
 


### PR DESCRIPTION
Due to a bug in eos-updater (T23385), upgrades from OS version 3.3 which
follow the checkpoint to move from the eos3 to the eos3a branch from
version 3.4 onwards do not remove the old eos:os/.../eos3 ref which
points to the last 3.3 release. This means that even after the 3.3 OS is
undeployed (after a second 3.4 update) the objects are kept around in
the OSTree repo - approx 3GB of wasted disk! Although we can fix the
updater bug for the next checkpoint, any system that has already
upgraded, and anyone else who uses the (still buggy) 3.3 updater to
follow the checkpoint, will have the leaked eos3 ref.

https://phabricator.endlessm.com/T23410