### PR TITLE
eos-update-flatpak-repos: remove eos2-related refs

### DIFF
--- a/eos-update-flatpak-repos
+++ b/eos-update-flatpak-repos
@@ -87,6 +87,13 @@ OSTREE_REFS_TO_REMOVE = [
     'eos:os/eos/amd64/eos3',
     'eos:os/eos/ec100/eos3',
     'eos:os/eos/nexthw/eos3'
+
+    # remove eos2 ref left behind after eos-upgrade-eos2-to-eos3 (T23443)
+    'eos:eos2/ec100',
+    'eos:eos2/i386',
+
+    # remove "initial factory commit" ref from pre-2.3.1 (T23443)
+    'local:factory',
 ]
 
 


### PR DESCRIPTION
Arguably this should have been done in https://github.com/endlessm/eos-customer-support/blob/master/eos-upgrade-eos2-to-eos3.

The ec100 ref name is a guess.

https://phabricator.endlessm.com/T23443