### PR TITLE
Enable PS2 keyboard wakeup on specific laptop systems

### DIFF
--- a/50-laptop-keyboard-wakeup.rules
+++ b/50-laptop-keyboard-wakeup.rules
@@ -1,0 +1,4 @@
+SUBSYSTEM=="input", ENV{ID_BUS}="i8042", ENV{ID_INPUT_KEYBOARD}="1", ATTR{[dmi/id]chassis_type}=="10", ATTR{[dmi/id]board_name}=="UX333FA", RUN+="/bin/sh -c 'echo enabled > /sys$env{DEVPATH}/../../../power/wakeup'"
+SUBSYSTEM=="input", ENV{ID_BUS}="i8042", ENV{ID_INPUT_KEYBOARD}="1", ATTR{[dmi/id]chassis_type}=="10", ATTR{[dmi/id]board_name}=="UX433FN", RUN+="/bin/sh -c 'echo enabled > /sys$env{DEVPATH}/../../../power/wakeup'"
+SUBSYSTEM=="input", ENV{ID_BUS}="i8042", ENV{ID_INPUT_KEYBOARD}="1", ATTR{[dmi/id]chassis_type}=="10", ATTR{[dmi/id]board_name}=="UX533FD", RUN+="/bin/sh -c 'echo enabled > /sys$env{DEVPATH}/../../../power/wakeup'"
+SUBSYSTEM=="input", ENV{ID_BUS}="i8042", ENV{ID_INPUT_KEYBOARD}="1", ATTR{[dmi/id]chassis_type}=="10", ATTR{[dmi/id]product_name}=="Swift SF314-55G", RUN+="/bin/sh -c 'echo enabled > /sys$env{DEVPATH}/../../../power/wakeup'"


### PR DESCRIPTION
ASUS new laptop models UX333FA, UX444FN, UX533FD and Acer Swift
SF314-55G which are powered by Intel WiskyLake CPUs and supports
s2idle can not wake up the system by keypress. It's due to the EC
does not signal SCI event by keypress after s2idle. The EC code
seems to be applied to coming models with new Intel WiskyLake CPUs.
Needs more models to verify.

To minimize impact and unwanted wakeups, we support keyboard wakeup
on specific systems identified by DMI.

https://phabricator.endlessm.com/T23406