### PR TITLE
udev/dracut: enable BFQ by default on disk devices

### DIFF
--- a/50-disk-bfq.rules
+++ b/50-disk-bfq.rules
@@ -1,0 +1,1 @@
+ACTION=="add|change", SUBSYSTEM=="block", ENV{DEVTYPE}=="disk", ATTR{queue/scheduler}="bfq"

--- a/Makefile.am
+++ b/Makefile.am
@@ -60,6 +60,7 @@ uninstall-hook:
 
 udevrulesdir = $(udevdir)/rules.d
 dist_udevrules_DATA = \
+	50-disk-bfq.rules \
 	50-laptop-keyboard-wakeup.rules \
 	50-meson-vdec.rules \
 	50-usb-mouse-wakeup.rules \

--- a/dracut/endless.conf
+++ b/dracut/endless.conf
@@ -9,3 +9,7 @@ early_microcode="yes"
 # between nouveau and nvidia.
 # (nouveau cannot be unloaded after it has bound to a device)
 omit_drivers="nouveau"
+
+# Ship the bfq IO scheduler module in the initrd, as it's relied upon by
+# our udev rules that detect block devices
+add_drivers+="bfq"


### PR DESCRIPTION
Set the scheduler to BFQ on block devices with a device type of disk, and add
the bfq module to the initrd so this udev rule works from early boot. This will
only impact SCSI devices on Endless systems, where we have switched the default
of the SCSI disk devices to the new MQ scheduler framework, which is a
pre-requisite of BFQ. Other block devices such as MMC which don't currently use
the MQ framework can't access BFQ, in which case this action is a no-op and the
current in-kernel default of CFQ remains.

https://phabricator.endlessm.com/T23725