### PR TITLE
Support virtio disks as well as SCSI disks

### DIFF
--- a/dracut/repartition/endless-repartition.sh
+++ b/dracut/repartition/endless-repartition.sh
@@ -66,11 +66,12 @@ get_last_char() {
 # - SCSI/MMC/NVMe block devices with different naming conventions
 # - A different partition numbering scheme as not all configurations have
 #   a ESP and a BIOS boot partition.
+# - Virtual block devices for OpenQA
 partno=$(get_last_char ${root_part})
 swap_partno=$((partno + 1))
 
 case ${root_part} in
-  /dev/sd??)
+  /dev/[sv]d??)
     root_disk=${root_part%?}
     ;;
   /dev/*p[0-9])

--- a/eos-extra-resize
+++ b/eos-extra-resize
@@ -22,7 +22,7 @@ case ${extra_part} in
     /dev/*p1)
         extra_disk=${extra_part%p1}
         ;;
-    /dev/sd?1)
+    /dev/[sv]d?1)
         extra_disk=${extra_part%1}
         ;;
 esac

--- a/eos-reclaim-swap
+++ b/eos-reclaim-swap
@@ -29,7 +29,8 @@ class SwapRemover():
         disk = None
 
         # /dev/sd[a-z][0-9]
-        if p.startswith('/dev/sd'):
+        # /dev/vd[a-z][0-9]
+        if p.startswith('/dev/sd') or p.startswith('/dev/vd'):
             disk = p[:-1]
 
         # /dev/[a-z]+p[0-9], but not /dev/sdp[0-9] (eMMC)


### PR DESCRIPTION
When running tests in OpenQA (which runs in QEMU), the disk uses the
virtio driver, whose devices are exposed as /dev/vd[a-z][0-9], rather
than /dev/sd[a-z][0-9].

Ensure that the disk repartitioning and resizing code handles these
device names. Critically, this ensures that the Endless partition is
resized to fill the virtual disk, rather than remaining about 6GB big
(which fills up rather fast and hence prevents any flatpaks from being
installed in OpenQA tests).

Signed-off-by: Philip Withnall <withnall@endlessm.com>

https://phabricator.endlessm.com/T23739