### PR TITLE
 Add Pressure Stall Information Monitor

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@ configure
 depcomp
 install-sh
 missing
+psi-monitor/psi-monitor
 test-driver
 tests/*.log
 tests/*.trs

--- a/Makefile.am
+++ b/Makefile.am
@@ -1,4 +1,4 @@
-SUBDIRS = dracut flatpak-repos nvidia tests
+SUBDIRS = dracut flatpak-repos nvidia psi-monitor tests
 EXTRA_DIST = debian
 
 # Install systemd units, generators, preset files, and udev rules

--- a/configure.ac
+++ b/configure.ac
@@ -4,6 +4,8 @@ AM_INIT_AUTOMAKE([foreign])
 AC_CONFIG_SRCDIR([eos-firstboot])
 PKG_PROG_PKG_CONFIG
 
+AC_PROG_CC
+
 dnl Get systemd unit and udev rules directories. Add options so that they
 dnl can be set under $prefix for distcheck.
 m4_define([no_systemdunitdir_error],
@@ -61,6 +63,7 @@ AC_CONFIG_FILES([
 	dracut/customization/Makefile
 	flatpak-repos/Makefile
 	nvidia/Makefile
+	psi-monitor/Makefile
 	tests/Makefile
 ])
 AC_OUTPUT

--- a/psi-monitor/Makefile.am
+++ b/psi-monitor/Makefile.am
@@ -1,0 +1,6 @@
+sbin_PROGRAMS = psi-monitor
+psi_monitor_SOURCES = psi-monitor.c
+
+dist_systemdunit_DATA = \
+	psi-monitor.service \
+	$(NULL)

--- a/psi-monitor/psi-monitor.c
+++ b/psi-monitor/psi-monitor.c
@@ -1,0 +1,100 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <stdbool.h>
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <fcntl.h>
+#include <err.h>
+#include <unistd.h>
+#include <string.h>
+
+#define DEBUG false
+
+/* Daemon parameters */
+#define POLL_INTERVAL       5
+#define RECOVERY_INTERVAL  15
+#define MEM_THRESHOLD      10
+
+#define SYSRQ_FILE          "/proc/sys/kernel/sysrq"
+#define SYSRQ_TRIGGER_FILE  "/proc/sysrq-trigger"
+#define PSI_MEMORY_FILE     "/proc/pressure/memory"
+#define SYSRQ_MASK          0x40
+#define BUFSIZE             256
+
+static void sysrq_trigger_oom() {
+    int fd;
+    ssize_t n;
+
+    printf("Above threshold limit, killing task and pausing for recovery\n");
+
+    fd = open(SYSRQ_TRIGGER_FILE, O_WRONLY);
+    if (fd < 0)
+        err(1, "%s", SYSRQ_TRIGGER_FILE);
+    n = write(fd, "f", strlen("f"));
+    if (n < 0)
+        err(1, "%s", SYSRQ_TRIGGER_FILE);
+    close(fd);
+    sleep(RECOVERY_INTERVAL);
+}
+
+static void sysrq_enable_oom() {
+    int fd, sysrq;
+    ssize_t n;
+    char buf[BUFSIZE];
+
+    fd = open(SYSRQ_FILE, O_RDONLY);
+    if (fd < 0)
+        err(1, "%s", SYSRQ_FILE);
+    n = read(fd, buf, BUFSIZE);
+    if (n < 0)
+        err(1, "%s", SYSRQ_FILE);
+    close(fd);
+    buf[n-1] = '\0';
+
+    sysrq = atoi(buf);
+    sysrq |= SYSRQ_MASK;
+    snprintf(buf, BUFSIZE, "%d", sysrq);
+    fd = open(SYSRQ_FILE, O_WRONLY);
+    if (fd < 0)
+        err(1, "%s", SYSRQ_FILE);
+    n = write(fd, buf, strlen(buf));
+    if (n < 0)
+        err(1, "%s", SYSRQ_FILE);
+    close(fd);
+}
+
+int main(int argc, char **argv) {
+    printf("poll_interval=%ds, recovery_interval=%ds, stall_threshold=%d%%\n",
+           POLL_INTERVAL, RECOVERY_INTERVAL, MEM_THRESHOLD);
+
+    sysrq_enable_oom();
+
+    while (true) {
+        int fd, i;
+        ssize_t n;
+        char buf[BUFSIZE];
+        float full_avg10;
+
+        fd = open(PSI_MEMORY_FILE, O_RDONLY);
+        if (fd < 0)
+            err(1, "%s", PSI_MEMORY_FILE);
+        n = read(fd, buf, BUFSIZE);
+        if (n < 0)
+            err(1, "%s", PSI_MEMORY_FILE);
+        close(fd);
+        buf[n-1] = '\0';
+
+        for (i = 0; buf[i] != '\n'; i++);
+        i++; /* skip \n */
+        i+=11; /* skip "full avg10=" */
+        sscanf(buf+i, "%f", &full_avg10);
+        if (DEBUG) printf("full_avg10=%f\n", full_avg10);
+
+        if (full_avg10 > MEM_THRESHOLD)
+            sysrq_trigger_oom();
+        else
+            sleep(POLL_INTERVAL);
+    }
+
+    return 0;
+}

--- a/psi-monitor/psi-monitor.c
+++ b/psi-monitor/psi-monitor.c
@@ -65,6 +65,7 @@ static void sysrq_enable_oom() {
 }
 
 int main(int argc, char **argv) {
+    setvbuf(stdout, NULL, _IOLBF, 0);
     printf("poll_interval=%ds, recovery_interval=%ds, stall_threshold=%d%%\n",
            POLL_INTERVAL, RECOVERY_INTERVAL, MEM_THRESHOLD);
 

--- a/psi-monitor/psi-monitor.service
+++ b/psi-monitor/psi-monitor.service
@@ -1,0 +1,11 @@
+[Unit]
+Description=Pressure Stall Information Monitor
+ConditionPathExists=/proc/pressure
+After=sysinit.target
+
+[Service]
+ExecStart=/usr/sbin/psi-monitor
+Restart=on-failure
+
+[Install]
+WantedBy=basic.target


### PR DESCRIPTION
Add a small service which will monitor pressure stall information (PSI)
from /proc/pressure and trigger the kernel's OOM killer when the system
enters a trashing state.

Since there is a chance the OOM killer may kill this service, it is set
to be restarted on failure by systemd.

https://phabricator.endlessm.com/T19943