### PR TITLE
eos-update-flatpak-repos: use Flatpak API to change branch names

### DIFF
--- a/eos-update-flatpak-repos
+++ b/eos-update-flatpak-repos
@@ -642,6 +642,18 @@ def _migrate_installed_flatpaks():
             assert (old_ostree_ref != new_ostree_ref)
 
             try:
+                # copy the old ref to the new one, pointing at the same commit
+                if old_ostree_ref in ostree_refs and \
+                   not new_ostree_ref in ostree_refs:
+                    logging.info('Copying OSTree ref {} [{}] to {}'
+                                 .format(old_ostree_ref,
+                                         ostree_refs[old_ostree_ref],
+                                         new_ostree_ref))
+                    repo.set_ref_immediate(new_origin,
+                                           new_ostree_ref.split(':')[1],
+                                           ostree_refs[old_ostree_ref])
+                    ostree_refs[new_ostree_ref] = ostree_refs[old_ostree_ref]
+
                 if new_branch != branch:
                     try:
                         new_ref = inst.get_installed_ref(kind, name, arch,
@@ -674,21 +686,11 @@ def _migrate_installed_flatpaks():
                     origin = new_origin
                     ref = _refresh_ref(inst, kind, name, arch, branch)
 
-                # when the branch or origin has changed, we copy the old ref to
-                # the new one, pointing at the same commit
-                if old_ostree_ref in ostree_refs and \
-                   not new_ostree_ref in ostree_refs:
-                    logging.info('Copying OSTree ref {} [{}] to {}'
-                                 .format(old_ostree_ref,
-                                         ostree_refs[old_ostree_ref],
-                                         new_ostree_ref))
-                    repo.set_ref_immediate(ref.get_origin(), ref.format_ref(),
-                                           ostree_refs[old_ostree_ref])
-                    ostree_refs[new_ostree_ref] = ostree_refs[old_ostree_ref]
-
             except Exception:
                 logging.exception('Failure applying migration to {}'
                                   .format(name))
+                # preserve the old ref so that the migration can be re-attempted
+                matching_ostree_refs.remove(old_ostree_ref)
                 continue
 
         # any refs we copied, along with any matches for apps we migrated

--- a/eos-update-flatpak-repos
+++ b/eos-update-flatpak-repos
@@ -480,6 +480,96 @@ def _filter_ostree_refs(refs, origin, kind, name='*', prefix=None, arch='*',
     return fnmatch.filter(refs, pattern)
 
 
+COMMIT_SUBJECT_INDEX = 3
+COMMIT_BODY_INDEX = 4
+
+
+def copy_commit(repo, src_rev, dest_ref, collection_id=None):
+    """Copy commit src_rev to dest_ref
+    This makes the new commit at dest_ref have the proper collection
+    binding for this repo. The caller is expected to manage the
+    ostree transaction.
+    This is like "flatpak build-commit-from", but we need more
+    control over the transaction.
+    """
+    logging.info('Copying commit %s to %s', src_rev, dest_ref)
+
+    _, src_root, _ = repo.read_commit(src_rev)
+    _, src_variant, src_state = repo.load_commit(src_rev)
+
+    # Only copy normal commits
+    if src_state != 0:
+        raise Exception('Cannot copy irregular commit {}'
+                        .format(src_rev))
+
+    # If the dest ref exists, use the current commit as the new
+    # commit's parent
+    _, dest_parent = repo.resolve_rev_ext(
+        dest_ref, allow_noent=True,
+        flags=OSTree.RepoResolveRevExtFlags.REPO_RESOLVE_REV_EXT_NONE)
+    if dest_parent is not None:
+        logging.info('Using %s as new commit parent', dest_parent)
+
+    # Make a copy of the commit metadata to update. Like flatpak
+    # build-commit-from, the detached metadata is not copied since
+    # the only known usage is for GPG signatures, which would become
+    # invalid.
+    commit_metadata = GLib.VariantDict.new(src_variant.get_child_value(0))
+
+    # Set the collection binding if the repo has a collection ID,
+    # otherwise remove it
+    if collection_id is not None:
+        commit_metadata.insert_value(
+            OSTree.COMMIT_META_KEY_COLLECTION_BINDING,
+            GLib.Variant('s', collection_id))
+    else:
+        commit_metadata.remove(
+            OSTree.COMMIT_META_KEY_COLLECTION_BINDING)
+
+    # Include the destination ref in the ref bindings
+    ref_bindings = commit_metadata.lookup_value(
+        OSTree.COMMIT_META_KEY_REF_BINDING,
+        GLib.VariantType('as'))
+    if ref_bindings is None:
+        ref_bindings = []
+    ref_bindings = set(ref_bindings)
+    ref_bindings.add(dest_ref)
+    commit_metadata.insert_value(
+        OSTree.COMMIT_META_KEY_REF_BINDING,
+        GLib.Variant('as', sorted(ref_bindings)))
+
+    # Add flatpak specific metadata. xa.ref is deprecated, but some
+    # flatpak clients might expect it. xa.from_commit will be used
+    # by the app verifier to make sure the commit it sent actually
+    # got there
+    commit_metadata.insert_value('xa.ref',
+                                 GLib.Variant('s', dest_ref))
+    commit_metadata.insert_value('xa.from_commit',
+                                 GLib.Variant('s', src_rev))
+
+    # Convert from GVariantDict to GVariant vardict
+    commit_metadata = commit_metadata.end()
+
+    # Copy other commit data from source commit
+    commit_subject = src_variant[COMMIT_SUBJECT_INDEX]
+    commit_body = src_variant[COMMIT_BODY_INDEX]
+    commit_time = OSTree.commit_get_timestamp(src_variant)
+
+    # Make the new commit assuming the caller started a transaction
+    mtree = OSTree.MutableTree.new()
+    repo.write_directory_to_mtree(src_root, mtree, None)
+    _, dest_root = repo.write_mtree(mtree)
+    _, dest_checksum = repo.write_commit_with_time(dest_parent,
+                                                   commit_subject,
+                                                   commit_body,
+                                                   commit_metadata,
+                                                   dest_root,
+                                                   commit_time)
+    logging.info('Created new commit %s', dest_checksum)
+
+    return dest_checksum
+
+
 def _migrate_installed_flatpaks():
     insts = Flatpak.get_system_installations()
     inst = insts[0]
@@ -566,10 +656,19 @@ def _migrate_installed_flatpaks():
                                  .format(old_ostree_ref,
                                          ostree_refs[old_ostree_ref],
                                          new_ostree_ref))
+                    try:
+                        repo.prepare_transaction()
+                        new_commit = copy_commit(repo,
+                                                 ostree_refs[old_ostree_ref],
+                                                 new_ostree_ref.split(':')[1])
+                        repo.commit_transaction()
+                    except:
+                        repo.abort_transaction()
+                        raise
                     repo.set_ref_immediate(new_origin,
                                            new_ostree_ref.split(':')[1],
-                                           ostree_refs[old_ostree_ref])
-                    ostree_refs[new_ostree_ref] = ostree_refs[old_ostree_ref]
+                                           new_commit)
+                    ostree_refs[new_ostree_ref] = new_commit
 
                 if new_branch != branch:
                     try:

--- a/eos-update-flatpak-repos
+++ b/eos-update-flatpak-repos
@@ -624,17 +624,22 @@ def _migrate_installed_flatpaks():
                               .format(kind.value_nick, prefix))
 
         for ref in matching_refs:
+            origin = ref.get_origin()
             name = ref.get_name()
             arch = ref.get_arch()
             branch = ref.get_branch()
-            logging.info('Found {}/{}/{} to migrate'
-                         .format(name, arch, branch))
+            old_ostree_ref = '{}:{}'.format(origin, ref.format_ref())
 
-            old_ostree_ref = '{}:{}'.format(ref.get_origin(), ref.format_ref())
+            new_origin = migrate.get('new-origin', origin)
+            new_branch = migrate.get('new-branch', branch)
+            new_ostree_ref = '{}:{}/{}/{}/{}'.format(new_origin, kind.value_nick,
+                                                     name, arch, new_branch)
+
+            logging.info('Found {} to migrate to {}'.format(old_ostree_ref,
+                         new_ostree_ref))
 
             try:
-                new_branch = migrate.get('new-branch')
-                if new_branch:
+                if new_branch != branch:
                     try:
                         new_ref = inst.get_installed_ref(kind, name, arch,
                                                          new_branch)
@@ -661,13 +666,10 @@ def _migrate_installed_flatpaks():
                 deploy_dir = ref.get_deploy_dir()
                 deploy = os.path.join(deploy_dir, 'deploy')
 
-                new_origin = migrate.get('new-origin')
-                if new_origin:
+                if new_origin != origin:
                     _update_deploy_file_with_origin(deploy, new_origin)
                     origin = new_origin
                     ref = _refresh_ref(inst, kind, name, arch, branch)
-
-                new_ostree_ref = '{}:{}'.format(ref.get_origin(), ref.format_ref())
 
                 # in the case the ref has not changed, we should remove it from
                 # the list of old refs so it will not be deleted

--- a/eos-update-flatpak-repos
+++ b/eos-update-flatpak-repos
@@ -638,6 +638,9 @@ def _migrate_installed_flatpaks():
             logging.info('Found {} to migrate to {}'.format(old_ostree_ref,
                          new_ostree_ref))
 
+            # if we're not changing anything, why are we here?
+            assert (old_ostree_ref != new_ostree_ref)
+
             try:
                 if new_branch != branch:
                     try:
@@ -670,14 +673,6 @@ def _migrate_installed_flatpaks():
                     _update_deploy_file_with_origin(deploy, new_origin)
                     origin = new_origin
                     ref = _refresh_ref(inst, kind, name, arch, branch)
-
-                # in the case the ref has not changed, we should remove it from
-                # the list of old refs so it will not be deleted
-                if new_ostree_ref == old_ostree_ref:
-                    logging.debug('OSTree ref {} unchanged'
-                                  .format(old_ostree_ref))
-                    matching_ostree_refs.remove(old_ostree_ref)
-                    continue
 
                 # when the branch or origin has changed, we copy the old ref to
                 # the new one, pointing at the same commit

--- a/eos-update-flatpak-repos
+++ b/eos-update-flatpak-repos
@@ -480,89 +480,6 @@ def _filter_ostree_refs(refs, origin, kind, name='*', prefix=None, arch='*',
     return fnmatch.filter(refs, pattern)
 
 
-def _replace_in_file(path, old, new):
-    _, data = GLib.file_get_contents(path)
-    assert data
-    GLib.file_set_contents(path, data.replace(old.encode('utf-8'),
-                                              new.encode('utf-8')))
-
-
-def _update_branch(ref, new_branch, refs):
-    kind = ref.get_kind()
-    name = ref.get_name()
-    arch = ref.get_arch()
-    branch = ref.get_branch()
-    deploy_dir = ref.get_deploy_dir()
-
-    clashing_refs = _filter_refs(refs, name=name, kind=kind,
-                                 arch=arch, branch=new_branch)
-    if len(clashing_refs) > 0:
-        logging.warning('Not migrating {}/{}/{}, new branch {} already exists'
-                        .format(name, arch, branch, new_branch))
-        raise FileExistsError
-
-    logging.info('Migrating {}/{}/{} to new branch {}'
-                 .format(name, arch, branch, new_branch))
-
-    # .../${kind}/${name}/${arch}/${branch} , ${ref}-${subpaths}
-    old_branch_dir, ref_dir = os.path.split(deploy_dir)
-
-    # .../${kind}/${name}/${arch}
-    arch_dir = os.path.dirname(old_branch_dir)
-
-    # .../${kind}/${name}
-    name_dir = os.path.dirname(arch_dir)
-    current = os.path.join(name_dir, 'current')
-    current_tmp = current + '.tmp'
-
-    # .../${kind}/${name}/${arch}/${new_branch}
-    new_branch_dir = os.path.join(arch_dir, new_branch)
-
-    # .../${kind}/${name}/${arch}/${new_branch}/${ref}-${subpaths}
-    new_deploy_dir = os.path.join(new_branch_dir, ref_dir)
-
-    try:
-        os.mkdir(new_branch_dir, mode=0o755)
-        subprocess.check_call(['cp', '-al', deploy_dir, new_deploy_dir])
-        os.symlink(ref_dir, os.path.join(new_branch_dir, 'active'))
-        if kind == Flatpak.RefKind.APP:
-            # update current symlink (specific to apps - runtimes
-            # always have a specified branch)
-            os.symlink('{}/{}'.format(arch, new_branch), current_tmp)
-            os.rename(current_tmp, current)
-
-            # update Exec= line in exported .desktop and .service files
-            old_exec = '/flatpak run --branch={} --arch={}'.format(branch,
-                                                                   arch)
-            new_exec = '/flatpak run --branch={} --arch={}'.format(new_branch,
-                                                                   arch)
-
-            for path in glob.glob(os.path.join(new_deploy_dir,
-                                  'export/share/applications/*.desktop')):
-                logging.debug('Updating branch in {}'.format(path))
-                _replace_in_file(path, old_exec, new_exec)
-
-            for path in glob.glob(os.path.join(new_deploy_dir,
-                                  'export/share/dbus-1/services/*.service')):
-                logging.debug('Updating branch in {}'.format(path))
-                _replace_in_file(path, old_exec, new_exec)
-
-    except Exception:
-        shutil.rmtree(new_branch_dir, ignore_errors=True)
-        if os.path.exists(current_tmp):
-            os.unlink(current_tmp)
-        raise
-
-    # this is unsafe whilst flatpaks are running
-    # however: this is a startup job
-    shutil.rmtree(old_branch_dir, ignore_errors=True)
-
-
-def _refresh_ref(inst, kind, name, arch, branch):
-    inst.drop_caches()
-    return inst.get_installed_ref(kind, name, arch, branch)
-
-
 def _migrate_installed_flatpaks():
     insts = Flatpak.get_system_installations()
     inst = insts[0]
@@ -658,33 +575,35 @@ def _migrate_installed_flatpaks():
                     try:
                         new_ref = inst.get_installed_ref(kind, name, arch,
                                                          new_branch)
+                        logging.info('Found already installed: {}'
+                                     .format(ref.format_ref()))
+
+                        # adopt installed origin if app was already installed
+                        new_origin = ref.get_origin()
                     except GLib.GError as e:
                         if not e.matches(Flatpak.error_quark(),
                                          Flatpak.Error.NOT_INSTALLED):
                             raise
-                    else:
-                        logging.info('{} already installed, removing {}'
-                                     .format(new_ref.format_ref(),
-                                             ref.format_ref()))
-                        inst.uninstall_full(Flatpak.UninstallFlags.NO_PRUNE,
-                                            kind, name, arch, branch)
 
-                        # do not continue to do any origin migrations if we already
-                        # have the app installed. the ostree ref is already part
-                        # of matching_ostree_refs so will be removed at the end.
-                        continue
+                        new_ref = None
 
-                    _update_branch(ref, new_branch, refs)
-                    branch = new_branch
-                    ref = _refresh_ref(inst, kind, name, arch, branch)
+                    if not new_ref:
+                        logging.info('Deploying with new ref: {}'.format(new_ostree_ref))
+                        new_ref = inst.install_full(Flatpak.InstallFlags.NO_PULL, new_origin,
+                                                    kind, name, arch, new_branch)
+
+                    logging.info('Uninstalling old ref: {}'.format(old_ostree_ref))
+                    inst.uninstall_full(Flatpak.UninstallFlags.NO_PRUNE, kind,
+                                        name, arch, branch)
+
+                    ref = new_ref
+                    origin = new_origin
 
                 deploy_dir = ref.get_deploy_dir()
                 deploy = os.path.join(deploy_dir, 'deploy')
 
                 if new_origin != origin:
                     _update_deploy_file_with_origin(deploy, new_origin)
-                    origin = new_origin
-                    ref = _refresh_ref(inst, kind, name, arch, branch)
 
             except Exception:
                 logging.exception('Failure applying migration to {}'


### PR DESCRIPTION
Copy the OSTree refs ahead of any Flatpak migrations so that we can use a NO_PULL deploy to install the Flatpak with the new branch name, as it will be created in a new folder. At a slight performance
cost (as the app will now be redeployed), the hair-raising update branch function which moved folders around and monkey patched the exported files behind Flatpak's back can be removed, significantly improving robustness and maintainability.

We now only directly access the deploy file in the case we are modifying the origin, but this code path is avoided if we've just done redeploy from the new ref, because it will already have the new origin. As this is the last and only action performed outside of the Flatpak API, we don't need to drop the cache or
refresh the ref.

https://phabricator.endlessm.com/T22902