### PR TITLE
Run flake8 during build

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,6 @@
+[flake8]
+# The default is 79 characters. One popular Python code formatter
+# https://github.com/ambv/black#line-length defaults to 88 which is based on
+# some empirical research on reducing annoying line wrapping on real source
+# code.
+max-line-length = 88

--- a/Makefile.am
+++ b/Makefile.am
@@ -1,5 +1,5 @@
 SUBDIRS = dracut flatpak-repos nvidia psi-monitor tests
-EXTRA_DIST = debian
+EXTRA_DIST = debian .flake8
 
 # Install systemd units, generators, preset files, and udev rules
 # under $prefix for distcheck

--- a/debian/control
+++ b/debian/control
@@ -5,6 +5,7 @@ Maintainer: Daniel Drake <drake@endlessm.com>
 Build-Depends: automake,
                debhelper (>= 8),
                dh-systemd,
+               flake8,
                pkg-config,
                python3,
                python3-parted,

--- a/debian/control
+++ b/debian/control
@@ -6,10 +6,10 @@ Build-Depends: automake,
                debhelper (>= 8),
                dh-systemd,
                pkg-config,
-               systemd,
-               udev,
                python3,
                python3-parted,
+               systemd,
+               udev,
 Standards-Version: 3.9.1
 Homepage: https://endlessm.com
 

--- a/eos-reclaim-swap
+++ b/eos-reclaim-swap
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/python3
 import argparse
 import contextlib
 import os

--- a/eos-update-flatpak-repos
+++ b/eos-update-flatpak-repos
@@ -34,7 +34,7 @@ from systemd import journal
 import gi
 gi.require_version('Flatpak', '1.0')
 gi.require_version('OSTree', '1.0')
-from gi.repository import Flatpak, Gio, GLib, OSTree
+from gi.repository import Flatpak, Gio, GLib, OSTree  # noqa: E402
 
 
 def _flatpak_inst_get_remote(inst, name):
@@ -99,7 +99,7 @@ def _remove_ostree_refs():
     try:
         repo = OSTree.Repo.new_default()
         repo.open()
-        _, ostree_refs = repo.list_refs() # dictionary of ref -> commit
+        _, ostree_refs = repo.list_refs()  # dictionary of ref -> commit
         for ref in OSTREE_REFS_TO_REMOVE:
             if ref in ostree_refs:
                 logging.info('Deleting leaked OSTree ref {}'.format(ref))
@@ -510,7 +510,9 @@ def mtree_add_file(repo, mtree, stream, file_info):
     file_info.set_attribute_uint32('unix::gid', 0)
     file_info.set_attribute_uint32('unix::mode', 0o100644)
 
-    _, content_stream, content_length = OSTree.raw_file_to_content_stream(stream, file_info, None)
+    _, content_stream, content_length = OSTree.raw_file_to_content_stream(
+        stream, file_info, None
+    )
     _, csum_bytes = repo.write_content(None, content_stream, content_length)
     csum = OSTree.checksum_from_bytes(csum_bytes)
     mtree.replace_file(file_info.get_name(), csum)
@@ -565,12 +567,16 @@ def rename_exports(repo, mtree, old_id, new_id, path='export'):
                 # will no longer match the name that is implemented internally
                 # so we have to disable it
                 try:
-                    da = desktop_file.get_boolean(GLib.KEY_FILE_DESKTOP_GROUP,
-                                                  GLib.KEY_FILE_DESKTOP_KEY_DBUS_ACTIVATABLE)
+                    da = desktop_file.get_boolean(
+                        GLib.KEY_FILE_DESKTOP_GROUP,
+                        GLib.KEY_FILE_DESKTOP_KEY_DBUS_ACTIVATABLE
+                    )
                     if da:
                         logging.debug('Removing DBusActivatable=true')
-                        desktop_file.remove_key(GLib.KEY_FILE_DESKTOP_GROUP,
-                                                GLib.KEY_FILE_DESKTOP_KEY_DBUS_ACTIVATABLE)
+                        desktop_file.remove_key(
+                            GLib.KEY_FILE_DESKTOP_GROUP,
+                            GLib.KEY_FILE_DESKTOP_KEY_DBUS_ACTIVATABLE
+                        )
                 except GLib.GError as e:
                     if not e.matches(GLib.KeyFile.error_quark(),
                                      GLib.KeyFileError.KEY_NOT_FOUND):
@@ -580,7 +586,9 @@ def rename_exports(repo, mtree, old_id, new_id, path='export'):
                 for key in [GLib.KEY_FILE_DESKTOP_KEY_ICON,
                             'X-Endless-SplashBackground']:
                     try:
-                        value = desktop_file.get_string(GLib.KEY_FILE_DESKTOP_GROUP, key)
+                        value = desktop_file.get_string(
+                            GLib.KEY_FILE_DESKTOP_GROUP, key
+                        )
                     except GLib.GError as e:
                         if not e.matches(GLib.KeyFile.error_quark(),
                                          GLib.KeyFileError.KEY_NOT_FOUND):
@@ -592,8 +600,9 @@ def rename_exports(repo, mtree, old_id, new_id, path='export'):
 
                 # Add old name to X-Flatpak-RenamedFrom
                 try:
-                    renamed_from = desktop_file.get_string_list(GLib.KEY_FILE_DESKTOP_GROUP,
-                                                                'X-Flatpak-RenamedFrom')
+                    renamed_from = desktop_file.get_string_list(
+                        GLib.KEY_FILE_DESKTOP_GROUP, 'X-Flatpak-RenamedFrom'
+                    )
                 except GLib.GError as e:
                     if not e.matches(GLib.KeyFile.error_quark(),
                                      GLib.KeyFileError.KEY_NOT_FOUND):
@@ -609,8 +618,7 @@ def rename_exports(repo, mtree, old_id, new_id, path='export'):
                 info.set_name(new_name)
                 mtree_add_keyfile(repo, mtree, desktop_file, info)
                 mtree.remove(name, False)
-            elif path == 'export/share/dbus-1/services' and \
-                 name.endswith('.service'):
+            elif path == 'export/share/dbus-1/services' and name.endswith('.service'):
                 logging.info('Not changing exported D-Bus service {}'.format(name))
             else:
                 logging.info('Renaming {} to {}'.format(name, new_name))
@@ -762,7 +770,7 @@ def _migrate_installed_flatpaks():
     # flatpak so we don't leave behind local refs to the old origin and branch.
     repo = OSTree.Repo.new(inst.get_path().get_child('repo'))
     repo.open()
-    _, ostree_refs = repo.list_refs() # dictionary of ref -> commit
+    _, ostree_refs = repo.list_refs()  # dictionary of ref -> commit
 
     for migrate in FLATPAKS_TO_MIGRATE:
         kind = migrate['kind']
@@ -878,7 +886,9 @@ def _migrate_installed_flatpaks():
                         # adopt installed origin if app was already installed
                         new_origin = new_ref.get_origin()
                     else:
-                        logging.info('Deploying with new ref: {}'.format(new_ostree_ref))
+                        logging.info(
+                            'Deploying with new ref: {}'.format(new_ostree_ref)
+                        )
                         new_ref = inst.install_full(Flatpak.InstallFlags.NO_PULL,
                                                     new_origin, kind, new_name,
                                                     arch, new_branch)

--- a/tests/check-syntax
+++ b/tests/check-syntax
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/python3
 import os
 import subprocess
 

--- a/tests/check-syntax
+++ b/tests/check-syntax
@@ -1,6 +1,7 @@
 #!/usr/bin/python3
 import os
 import subprocess
+import glob
 
 ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))
 
@@ -30,6 +31,12 @@ def main():
 
     for dash_script in find_files("^#!/bin/sh"):
         checks.append(["dash", "-n", dash_script])
+
+    # All files with a shebang, regardless of their extension (if any)
+    python_scripts = set(find_files("^#!/usr/bin/python"))
+    # .py files in the tests/ directory, which may or may not have a hashtag yell
+    python_scripts.update(glob.glob(os.path.join(ROOT, 'tests', '*.py')))
+    checks.append(["flake8"] + sorted(python_scripts))
 
     print('1..{}'.format(len(checks)))
     failed = False

--- a/tests/test_image_boot.py
+++ b/tests/test_image_boot.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/python3
 '''
 Must be run as a user privileged enough to run
 `losetup`. If run as an unprivileged user, all tests are skipped.

--- a/tests/test_live_boot_generator.py
+++ b/tests/test_live_boot_generator.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/python3
 '''Exercises eos-live-boot-generator for the live and !live cases.'''
 
 import os

--- a/tests/test_reclaim_swap.py
+++ b/tests/test_reclaim_swap.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/python3
 '''
 Tests eos-reclaim-swap.
 '''

--- a/tests/test_repartition.py
+++ b/tests/test_repartition.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/python3
 '''
 Tests endless-repartition.sh. Must be run as a user privileged enough to run
 `losetup`. If run as an unprivileged user, all tests are skipped.

--- a/tests/test_repartition_mbr.py
+++ b/tests/test_repartition_mbr.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/python3
 '''
 Tests eos-repartition-mbr. Must be run as a user privileged enough to run
 `losetup`. If run as an unprivileged user, all tests are skipped.


### PR DESCRIPTION
I was reviewing https://github.com/endlessm/eos-boot-helper/pull/236 and found bugs just by running `flake8`, so let's automate that.