### PR TITLE
eos-update-flatpak-repos: update X-Flatpak-RenamedFrom

### DIFF
--- a/eos-update-flatpak-repos
+++ b/eos-update-flatpak-repos
@@ -590,6 +590,22 @@ def rename_exports(repo, mtree, old_id, new_id, path='export'):
                     value = value.replace(old_id, new_id)
                     desktop_file.set_string(GLib.KEY_FILE_DESKTOP_GROUP, key, value)
 
+                # Add old name to X-Flatpak-RenamedFrom
+                try:
+                    renamed_from = desktop_file.get_string_list(GLib.KEY_FILE_DESKTOP_GROUP,
+                                                                'X-Flatpak-RenamedFrom')
+                except GLib.GError as e:
+                    if not e.matches(GLib.KeyFile.error_quark(),
+                                     GLib.KeyFileError.KEY_NOT_FOUND):
+                        raise
+                    renamed_from = []
+
+                if name not in renamed_from:
+                    renamed_from.append(name)
+                desktop_file.set_string_list(GLib.KEY_FILE_DESKTOP_GROUP,
+                                             'X-Flatpak-RenamedFrom',
+                                             renamed_from)
+
                 info.set_name(new_name)
                 mtree_add_keyfile(repo, mtree, desktop_file, info)
                 mtree.remove(name, False)

--- a/tests/test_update_flatpak_repos.py
+++ b/tests/test_update_flatpak_repos.py
@@ -1,0 +1,110 @@
+#!/usr/bin/python3
+"""
+Tests eos-update-flatpak-repos
+"""
+
+import importlib.util
+import importlib.machinery
+import tempfile
+import textwrap
+
+from .util import BaseTestCase, system_script
+import gi
+
+gi.require_version("OSTree", "1.0")
+from gi.repository import Gio, OSTree  # noqa: E402
+
+
+# Import script as a module, despite its filename not being a legal module name
+spec = importlib.util.spec_from_loader(
+    "eufr",
+    importlib.machinery.SourceFileLoader(
+        "eufr", system_script("eos-update-flatpak-repos")
+    ),
+)
+eufr = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(eufr)
+
+
+class TestMangleDesktopFile(BaseTestCase):
+    def setUp(self):
+        self.tmp = tempfile.TemporaryDirectory()
+
+    def tearDown(self):
+        self.tmp.cleanup()
+
+    def _ensure_dirs(self, mtree, *dirs):
+        for name in dirs:
+            _, mtree = mtree.ensure_dir(name)
+        return mtree
+
+    def test_rename_main_desktop(self):
+        orig_name = "com.example.Hello.desktop"
+        orig_data = textwrap.dedent(
+            """
+            [Desktop Entry]
+            DBusActivatable=true
+            Icon=com.example.Hello
+            X-Flatpak-RenamedFrom=net.example.Howdy.desktop;
+            """
+        ).strip()
+
+        expected_name = "org.example.Hi.desktop"
+        expected_data = textwrap.dedent(
+            """
+            [Desktop Entry]
+            Icon=org.example.Hi
+            X-Flatpak-RenamedFrom=net.example.Howdy.desktop;com.example.Hello.desktop;
+            """
+        ).strip()
+
+        self._test(orig_name, orig_data, expected_name, expected_data)
+
+    def test_rename_extra_desktop(self):
+        orig_name = "com.example.Hello.Again.desktop"
+        orig_data = textwrap.dedent(
+            """
+            [Desktop Entry]
+            Icon=com.example.Hello.Next
+            """
+        ).strip()
+
+        expected_name = "org.example.Hi.Again.desktop"
+        expected_data = textwrap.dedent(
+            """
+            [Desktop Entry]
+            Icon=org.example.Hi.Next
+            X-Flatpak-RenamedFrom=com.example.Hello.Again.desktop;
+            """
+        ).strip()
+
+        self._test(orig_name, orig_data, expected_name, expected_data)
+
+    def _test(self, orig_name, orig_data, expected_name, expected_data):
+        repo = OSTree.Repo.new(Gio.File.new_for_path(self.tmp.name))
+        repo.set_disable_fsync(True)
+        repo.create(OSTree.RepoMode.BARE_USER_ONLY)
+
+        mtree = OSTree.MutableTree()
+
+        # Store the original file in the tree
+        data_bytes = orig_data.encode("utf-8")
+        stream = Gio.MemoryInputStream.new_from_data(data_bytes)
+        info = Gio.FileInfo()
+        info.set_size(len(data_bytes))
+        info.set_name(orig_name)
+
+        _, export = mtree.ensure_dir("export")
+        _, share = export.ensure_dir("share")
+        _, apps = share.ensure_dir("applications")
+        eufr.mtree_add_file(repo, apps, stream, info)
+
+        # Rename the contents of the export/ directory
+        eufr.rename_exports(repo, export, "com.example.Hello", "org.example.Hi")
+
+        # Check the applications/ subdirectory is as we expect
+        files = apps.get_files()
+        self.assertEqual(list(files.keys()), [expected_name])
+        _, stream, info, _ = repo.load_file(files[expected_name])
+        bytes_ = stream.read_bytes(info.get_size())
+        self.assertEqual(bytes_.get_data().decode("utf-8").strip(), expected_data)


### PR DESCRIPTION
Our Flatpak is patched to propagate a previous-ids property from old
to new deploy file when deploying an app update, and to add all previous
IDs to the X-Flatpak-RenamedFrom key in the process.

However, in this script we only set previous-ids after deploying the
patched version of the app (under its new name). In any case, as far as
Flatpak is concerned, this is a wholly new app being installed, so there
would be no previous deployment to carry previous-ids forward from.

Since we are patching the .desktop files anyway while doing the
migration, we can just implement the same logic to update
X-Flatpak-RenamedFrom here, and add a test for this and other .desktop
file mangling.

I have not tested this on a real system, but in my defence I did write a test.

https://phabricator.endlessm.com/T23845