### PR TITLE
eos-update-flatpak-repos: don't log twice to journal

### DIFF
--- a/eos-update-flatpak-repos
+++ b/eos-update-flatpak-repos
@@ -28,6 +28,7 @@ import fnmatch
 import logging
 import os
 import subprocess
+import sys
 
 from systemd import journal
 
@@ -1536,9 +1537,12 @@ def _migrate_installed_flatpaks():
 
 
 if __name__ == '__main__':
-    # Send logging messages both to the console and the journal
-    logging.basicConfig(level=logging.INFO)
-    logging.root.addHandler(journal.JournalHandler())
+    # Send logging messages to the journal, and to stderr if it's a tty (which
+    # implies it's not the journal)
+    handlers = [journal.JournalHandler()]
+    if sys.stderr.isatty():
+        handlers.append(logging.StreamHandler(sys.stderr))
+    logging.basicConfig(level=logging.INFO, handlers=handlers)
 
     parser = argparse.ArgumentParser()
     parser.add_argument('--debug', '-d', dest='debug', action='store_true')


### PR DESCRIPTION
logging.basicConfig(), if called without any handlers (and with no
handlers previously configured), adds a logging.StreamHandler for stderr.
After calling it, we previously unconditionally configured a
JournalHandler to send log output to the systemd journal.

When run interactively, stderr isn't connected to the journal; but when
run for real after an upgrade, it is. This meant we logged everything to
the journal twice, making it rather hard to read. As it happens, the
prefix on each line was the same length, which helped a bit:

```
Oct 08 11:22:10 endless eos-update-flatpak-repos[332]: INFO:root:Found eos-apps:app/org.stellarium.Stellarium/x86_64/eos3 to migrate to flathub:app/org.stellarium.Stellarium/x86_64/stable
Oct 08 11:22:10 endless /usr/sbin/eos-update-flatpak-repos[332]: Found eos-apps:app/org.stellarium.Stellarium/x86_64/eos3 to migrate to flathub:app/org.stellarium.Stellarium/x86_64/stable
```

But it's easy enough to avoid this. GLib includes a function to check
whether a file descriptor is connected to the journal; use this to avoid
setting up a StreamHandler in that case.

https://phabricator.endlessm.com/T24289