### PR TITLE
eos-reclaim-swap: avoid cylinder alignment for DOS partition tables

### DIFF
--- a/eos-reclaim-swap
+++ b/eos-reclaim-swap
@@ -55,6 +55,8 @@ class SwapRemover():
         '''
         dev = parted.getDevice(disk_path)
         disk = parted.newDisk(dev)
+        if disk.type == "msdos":
+            disk.unsetFlag(parted.DISK_CYLINDER_ALIGNMENT)
         parts = disk.partitions
 
         for p, part in enumerate(parts):
@@ -69,6 +71,8 @@ class SwapRemover():
                 constraint = parted.Constraint(maxGeom=geom)
                 disk.removePartition(part)
                 disk.maximizePartition(parts[p-1], constraint)
+                if parts[p-1].geometry.start != geom.start:
+                    raise Exception("Operation would change partition start")
                 # The disk is in use at this point, which means parted will not
                 # be able to update the kernel with the new partition table and
                 # it will raise an exception. Lets suppress the exception here


### PR DESCRIPTION
For DOS partition tables, the msdos_partition_align() function called
in the disk.maximizePartition() codepath was modifying the partition
start, aligning it based on BIOS cylinder calculations. Drop that
constraint so that the sector will be unchanged.

This was causing the new partition to be written with a different start
sector (144585 instead of 131072), but here we are only trying to modify
the end. Add a sanity check to prevent that from happening again for
any reason.

https://phabricator.endlessm.com/T24454