### PR TITLE
Add eos-factory-reset systemd units

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -15,6 +15,7 @@ dist_systemdunit_DATA = \
 	eos-config-journal.service \
 	eos-enable-zram.service \
 	eos-extra-resize.service \
+	eos-factory-reset.service \
 	eos-firewall-localonly.service \
 	eos-firstboot.service \
 	eos-image-boot-dm-setup.service \
@@ -74,6 +75,7 @@ dist_sbin_SCRIPTS = \
 	eos-config-journal \
 	eos-enable-zram \
 	eos-extra-resize \
+	eos-factory-reset \
 	eos-firewall-localonly \
 	eos-firstboot \
 	eos-image-boot-dm-setup \
@@ -81,6 +83,12 @@ dist_sbin_SCRIPTS = \
 	eos-reclaim-swap \
 	eos-repartition-mbr \
 	eos-update-flatpak-repos \
+	$(NULL)
+
+eosfactoryresetdir = $(prefix)/lib/eos-factory-reset
+dist_eosfactoryreset_SCRIPTS = \
+	eos-factory-reset-helper \
+	eos-factory-reset-users-helper \
 	$(NULL)
 
 tmpfilesdir = $(prefix)/lib/tmpfiles.d

--- a/eos-factory-reset
+++ b/eos-factory-reset
@@ -1,0 +1,89 @@
+#!/bin/bash -e
+
+cmd_name=$(basename "$0")
+
+usage () {
+    cat <<EOF
+Usage: $cmd_name
+Reboot the machine and perform a factory reset.
+
+  -u               reset all users only
+  -a               make a full factory reset
+  -f, --force      don't ask for user confirmation
+  -h, --help       display this help and exit
+
+EOF
+}
+
+args=$(getopt -o u,a,f,h -l "force,help" -n "$cmd_name" -- "$@") || exit 1
+
+eval set -- "$args"
+
+reset_stages=""
+ask_confirmation=1
+
+while true; do
+    case "$1" in
+        -u)
+            reset_stages="USERS $reset_stages"
+            shift
+            ;;
+        -a)
+            reset_stages="USERS"
+            shift
+            ;;
+        -f|--force)
+            ask_confirmation=0
+            shift
+            ;;
+        -h|--help)
+            usage
+            exit 0
+            ;;
+        --)
+            shift
+            ;;
+        *)
+            break
+            ;;
+    esac
+done
+
+# Check that script was run with superuser privileges.
+if [[ $EUID != 0 ]]; then
+    echo "$cmd_name requires superuser privileges."
+    exit 1
+fi
+
+if [ -z $reset_stages ]; then
+    echo "$cmd_name: No stages were selected"
+    exit 1
+fi
+
+
+if [ $ask_confirmation -eq 1 ]; then
+    echo "This tool will perform a factory reset, which will delete all"
+    echo "users and their documents, images, etc. forever."
+    echo ""
+    echo "During this process, you'll see a black screen for a few seconds"
+    echo "and then the system will be restarted."
+    echo ""
+    echo "Selected factory reset stages: $reset_stages"
+    echo ""
+    echo "WARNING: These changes are IRREVERSIBLE."
+    echo ""
+
+    read -rp "Are you sure you want to proceed? [y/n] "
+    response="${REPLY,,}" # to lower
+    if [[ ! "$response" =~ ^(yes|y)$ ]]; then
+        exit 1
+    fi
+fi
+
+flag_file=/var/.eos-factory-reset
+echo -n > $flag_file
+for reset_stage in $reset_stages; do
+    echo "EOS_FACTORY_RESET_$reset_stage=1" >> $flag_file
+done
+
+systemctl reboot

--- a/eos-factory-reset-helper
+++ b/eos-factory-reset-helper
@@ -1,0 +1,32 @@
+#!/bin/bash
+
+run_stage () {
+    stage_var_name=EOS_FACTORY_RESET_$1
+    if [ "${!stage_var_name}" = 1 ]; then
+        echo "Running factory reset stage $1"
+        "$(dirname "$0")/eos-factory-reset-${1,,}-helper"
+    else
+        echo "Skipping factory reset stage $1"
+    fi
+}
+
+flag_file=/var/.eos-factory-reset
+cmd_name=$(basename "$0")
+
+# Check that script was run with superuser privileges.
+if [[ $EUID != 0 ]]; then
+    echo "$cmd_name requires superuser privileges."
+    exit 1
+fi
+
+# Check if flag file exists
+if [ ! -f $flag_file ]; then
+    echo "$cmd_name: flag file '$flag_file' does not exist"
+    exit 1
+fi
+
+# shellcheck source=/dev/null
+. $flag_file
+rm -v $flag_file
+
+run_stage USERS

--- a/eos-factory-reset-users-helper
+++ b/eos-factory-reset-users-helper
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+if [ -f /etc/adduser.conf ]; then
+    . /etc/adduser.conf
+fi
+
+first_uid=${FIRST_UID:-1000}
+last_uid=${LAST_UID:-59999}
+
+IFS=':'
+while read -r user _ uid _ _ _ _; do
+    if [[ $uid -ge $first_uid && $uid -le $last_uid ]]; then
+        echo "Deleting user $user ($uid)"
+        userdel -r "$user"
+    fi
+done </etc/passwd

--- a/eos-factory-reset.service
+++ b/eos-factory-reset.service
@@ -1,0 +1,18 @@
+[Unit]
+Description=Endless factory reset service
+ConditionPathExists=/var/.eos-factory-reset
+RefuseManualStart=yes
+DefaultDependencies=no
+Requires=sysinit.target
+After=sysinit.target local-fs.target
+Before=shutdown.target basic.target
+Conflicts=shutdown.target
+
+[Service]
+Type=oneshot
+ExecStart=/usr/lib/eos-factory-reset/eos-factory-reset-helper
+StandardOutput=journal+console
+StandardError=journal+console
+
+[Install]
+WantedBy=basic.target


### PR DESCRIPTION
This is to complete https://github.com/endlessm/eos-meta/pull/536 . I wasn't sure if you wanted the `eos-factory-reset` scripts here or in `eos-meta` so I leaved it in `eos-meta`. But it'd be probably a good idea to move those to this repo.

https://phabricator.endlessm.com/T24613