### PR TITLE
eos-config-journal: detect MMC on dual-boot systems

### DIFF
--- a/eos-config-journal
+++ b/eos-config-journal
@@ -13,7 +13,7 @@ device=$(df --output=source $parentdir | tail -n 1)
 
 # will contain non-empty string if this device is an MMC or SD device (both of
 # which are susceptible to damage with excessive writing)
-subsystem=$(lsblk --noheading -o SUBSYSTEMS "$device" | grep '^block:mmc' \
+subsystem=$(lsblk --noheading -o SUBSYSTEMS --inverse "$device" | grep '^block:mmc' \
     || true)
 
 if [ "x$subsystem" != "x" ]; then


### PR DESCRIPTION
On a dual-boot eMMC system, `/dev/mapper/endless-image3` has SUBSYSTEMS=block. `lsblk` knows that its ancestor partition, eg `/dev/mmcblk0p3`, has SUBSYSTEMS=block:mmc:mmc_host:pci, but `lsblk DEVICE` shows information about DEVICE and its descendents, not its ancestors. Passing --inverse causes it to show the ancestors instead.

I don't have a dual-boot device easily accessible right now (and don't have a Windows computer with eMMC at all) so I've not actually tested this change in situ.

https://phabricator.endlessm.com/T25023