### PR TITLE
eos-update-flatpak-repos: fix migrating non-extra data apps

### DIFF
--- a/eos-update-flatpak-repos
+++ b/eos-update-flatpak-repos
@@ -1232,8 +1232,13 @@ def rewrite_app_id(repo, mtree, old_id, new_id):
     # folder from the pre-migration deploy folder. the migration function
     # examines the commit metadata of the app being migrated to determine
     # whether the re-deploy has to carry out this extra step.
-    if metadata.has_group(FLATPAK_METADATA_GROUP_EXTRA_DATA):
+    try:
         metadata.remove_group(FLATPAK_METADATA_GROUP_EXTRA_DATA)
+    except GLib.GError as e:
+        if not e.matches(GLib.key_file_error_quark(),
+                         GLib.KeyFileError.GROUP_NOT_FOUND):
+            raise
+    else:
         logging.info('Removing [Extra Data] from {} metadata'.format(old_id))
 
     metadata_str = mtree_add_keyfile(repo, mtree, metadata, info)

--- a/eos-update-flatpak-repos
+++ b/eos-update-flatpak-repos
@@ -1234,12 +1234,11 @@ def rewrite_app_id(repo, mtree, old_id, new_id):
     # whether the re-deploy has to carry out this extra step.
     try:
         metadata.remove_group(FLATPAK_METADATA_GROUP_EXTRA_DATA)
+        logging.info('Removing [Extra Data] from {} metadata'.format(old_id))
     except GLib.GError as e:
         if not e.matches(GLib.key_file_error_quark(),
                          GLib.KeyFileError.GROUP_NOT_FOUND):
             raise
-    else:
-        logging.info('Removing [Extra Data] from {} metadata'.format(old_id))
 
     metadata_str = mtree_add_keyfile(repo, mtree, metadata, info)
 

--- a/eos-update-flatpak-repos
+++ b/eos-update-flatpak-repos
@@ -1232,7 +1232,8 @@ def rewrite_app_id(repo, mtree, old_id, new_id):
     # folder from the pre-migration deploy folder. the migration function
     # examines the commit metadata of the app being migrated to determine
     # whether the re-deploy has to carry out this extra step.
-    if metadata.remove_group(FLATPAK_METADATA_GROUP_EXTRA_DATA):
+    if metadata.has_group(FLATPAK_METADATA_GROUP_EXTRA_DATA):
+        metadata.remove_group(FLATPAK_METADATA_GROUP_EXTRA_DATA)
         logging.info('Removing [Extra Data] from {} metadata'.format(old_id))
 
     metadata_str = mtree_add_keyfile(repo, mtree, metadata, info)

--- a/tests/test_update_flatpak_repos.py
+++ b/tests/test_update_flatpak_repos.py
@@ -198,7 +198,7 @@ class TestMangleMetadataAndDesktopFile(BaseTestCase):
         self.assertFalse(metadata.has_group('Extra Data'))
 
         # TODO: test the end-to-end migration process, including copying the
-        # old extra data into plaice
+        # old extra data into plaice 🐟
 
     def _mkdir_p(self, path):
         mtree = self.mtree

--- a/tests/test_update_flatpak_repos.py
+++ b/tests/test_update_flatpak_repos.py
@@ -198,7 +198,7 @@ class TestMangleMetadataAndDesktopFile(BaseTestCase):
         self.assertFalse(metadata.has_group('Extra Data'))
 
         # TODO: test the end-to-end migration process, including copying the
-        # old extra data into plaice 🐟
+        # old extra data into place
 
     def _mkdir_p(self, path):
         mtree = self.mtree

--- a/tests/test_update_flatpak_repos.py
+++ b/tests/test_update_flatpak_repos.py
@@ -39,11 +39,6 @@ class TestMangleDesktopFile(BaseTestCase):
     def tearDown(self):
         self.tmp.cleanup()
 
-    def _ensure_dirs(self, mtree, *dirs):
-        for name in dirs:
-            _, mtree = mtree.ensure_dir(name)
-        return mtree
-
     def test_rename_empty_desktop(self):
         '''No keys we care about'''
         orig_name = "com.example.Hello.desktop"


### PR DESCRIPTION
fa409368c1ffbce4be40a3b79f449b71f9ae072d added support for migrating extra data apps, but broke migrating normal apps:

    Failure applying migration to com.github.Slingshot
   Traceback (most recent call last):
     File "/usr/sbin/eos-update-flatpak-repos", line 1495, in _migrate_installed_flatpaks
       **kwargs,
     File "/usr/sbin/eos-update-flatpak-repos", line 1331, in copy_commit
       metadata, vendor_prefixes = rewrite_app_id(repo, mtree, old_app_id, new_app_id)
     File "/usr/sbin/eos-update-flatpak-repos", line 1235, in rewrite_app_id
       if metadata.remove_group(FLATPAK_METADATA_GROUP_EXTRA_DATA):
   GLib.GError: g-key-file-error-quark: Key file does not have group “Extra Data” (4)

This is because g_key_file_remove_group() returns FALSE with the GError set if the group is not present; this becomes an exception in Python.

Fix this, and add (gasp) a test!

https://phabricator.endlessm.com/T23856