### PR TITLE
fallback-fb-setup: Fix executable path in unit file

### DIFF
--- a/fallback-fb-setup/fallback-fb-setup.service
+++ b/fallback-fb-setup/fallback-fb-setup.service
@@ -4,7 +4,7 @@ Requires=display-manager.service
 After=display-manager.service
 
 [Service]
-ExecStart=/usr/libexec/fallback-fb-setup/fallback-fb-setup
+ExecStart=/usr/lib/eos-boot-helper/fallback-fb-setup/fallback-fb-setup
 
 [Install]
 WantedBy=graphical.target


### PR DESCRIPTION
Use the correct path for the service binary.

https://phabricator.endlessm.com/T24682