### PR TITLE
factory-reset: Fix executable path in unit file

### DIFF
--- a/factory-reset/eos-factory-reset-users.service
+++ b/factory-reset/eos-factory-reset-users.service
@@ -24,7 +24,7 @@ Before=systemd-user-sessions.service
 
 [Service]
 Type=oneshot
-ExecStart=/usr/libexec/eos-factory-reset/eos-factory-reset-users
+ExecStart=/usr/lib/eos-boot-helper/eos-factory-reset/eos-factory-reset-users
 ExecStopPost=/usr/bin/systemctl disable %n
 
 [Install]


### PR DESCRIPTION
Use the correct path for the reset-users service binary.

https://phabricator.endlessm.com/T24613