### PR TITLE
image-boot: install 95-dm-notify.rules

### DIFF
--- a/dracut/image-boot/module-setup.sh
+++ b/dracut/image-boot/module-setup.sh
@@ -12,7 +12,7 @@ depends() {
 install() {
   dracut_install blockdev kpartx dmsetup dumpexfat ntfsextents lsblk losetup
   instmods overlay
-  inst_rules 55-dm.rules 60-cdrom_id.rules
+  inst_rules 55-dm.rules 60-cdrom_id.rules 95-dm-notify.rules
   inst_script "$moddir"/eos-image-boot-setup /bin/eos-image-boot-setup
   inst_script "$moddir"/eos-live-early-overlayfs-setup /bin/eos-live-early-overlayfs-setup
   inst_script "$moddir"/eos-map-image-file /bin/eos-map-image-file


### PR DESCRIPTION
With the new lvm2 version in debian buster, common dmsetup commands
seem to wait for udev rules to communicate completion. If this rules
file is not present, the "dmsetup create" hangs indefinitely.

https://phabricator.endlessm.com/T25331