### PR TITLE
eos-image-boot: read device mapper name from sysfs attributes

### DIFF
--- a/dracut/image-boot/eos-image-boot-generator
+++ b/dracut/image-boot/eos-image-boot-generator
@@ -58,7 +58,7 @@ EOF
 if getargbool 0 endless.live_boot; then
   rwflag=ro
   # Allow live user to read mapped image directly (in particular, when reflashing)
-  echo 'SUBSYSTEM=="block", ENV{DM_NAME}=="endless-image", MODE="0664"' >> /run/udev/rules.d/79-endless-image.rules
+  echo 'SUBSYSTEM=="block", ATTR{dm/name}=="endless-image", MODE="0664"' >> /run/udev/rules.d/79-endless-image.rules
 else
   rwflag=rw
 fi


### PR DESCRIPTION
55-dm.rules looks like it should take care of setting the DM_NAME
udev variable for device mapper devices. However, in our case, it is
not doing this. The flow is hard to analyze but I observed that it's
not setting the name, and is instead reaching the dm_disable section
where it asks udev to stop watching the device.

DM_NAME was being set anyway because 60-kpartx.rules used to trigger
and call dmsetup_env to set these variables, but as of the new
multipath-tools version, that no longer happens for this device.

Just read the device mapper name from /sys attributes directly,
avoiding dependence on 55-dm.rules which is not working as we would hope.

https://phabricator.endlessm.com/T25493