### PR TITLE
eos-preset: disable speech-dispatcherd.service

### DIFF
--- a/50-eos.preset
+++ b/50-eos.preset
@@ -25,6 +25,7 @@ disable openvpn.service
 disable openvpn@.service
 disable rtkit-daemon.service
 disable serial-getty@.service
+disable speech-dispatcherd.service
 disable ssh*.service
 disable ssh.socket
 disable systemd-nspawn@.service


### PR DESCRIPTION
It fails to start due to the lack of a system-wide PulseAudio session:

  pulse.c: pa_simple_new() failed: Connection refused

According to README.Debian, running a system-wide instance of this
daemon is not a recommended configuration, and debian/rules uses
"dh_systemd_enable --no-enable" to disable it by default on Debian
systems. Disable it here, too. (Previously, the package did not include
a .service file, and the init script checked an off-by-default flag in
/etc/default/speech-dispatcher.)

https://phabricator.endlessm.com/T25605