### PR TITLE
eos-update-flatpak-repos: migrate GNOME 3.28 runtime

### DIFF
--- a/eos-update-flatpak-repos
+++ b/eos-update-flatpak-repos
@@ -304,6 +304,13 @@ FLATPAKS_TO_MIGRATE = [
         'old-origin': 'gnome',
         'new-origin': 'flathub'
     },
+    {
+        'prefix': 'org.gnome.',
+        'kind': Flatpak.RefKind.RUNTIME,
+        'old-branch': '3.28',
+        'old-origin': 'gnome',
+        'new-origin': 'flathub'
+    },
     # migrate eos-apps to flathub where the app ID is the same (T20724)
     {
         'name': 'com.google.AndroidStudio',


### PR DESCRIPTION
A speculative fix for the issue reported on
https://community.endlessos.com/t/update-fail-use-endless-os-3-3-19/8848.
This user has org.gnome.Platform//3.28 installed from the 'gnome'
remote, but does not have a 'gnome' remote, because the eos3.3 version
of this script forcibly deletes it.

https://phabricator.endlessm.com/T25809