### PR TITLE
eos-preset: Disable wpa_supplicant-nl80211@.service

### DIFF
--- a/50-eos.preset
+++ b/50-eos.preset
@@ -31,6 +31,7 @@ disable ssh.socket
 disable systemd-nspawn@.service
 disable wpa_supplicant.service
 disable wpa_supplicant@.service
+disable wpa_supplicant-nl80211@.service
 disable wpa_supplicant-wired@.service
 
 # Disable units masked by Debian, as systemctl preset-all fails to


### PR DESCRIPTION
We don't want to enable any unit from wpa_supplicant as we don't
configure interfaces individually outside of Network Manager. Network
Manager starts wpa_supplicant via D-Bus when needed.

This also times-out during boot, adding a 90s delay because it requires
sys-subsystem-net-devices-multi-user.device, which does not exist.

https://phabricator.endlessm.com/T25608