### PR TITLE
nvidia: unblacklist Acer Nitro N50-600

### DIFF
--- a/nvidia/dmi-blacklist
+++ b/nvidia/dmi-blacklist
@@ -5,8 +5,5 @@
 # delimiter: ,
 # Quote character: "
 
-# Occasional hang upon S3 resume (GTX1060) (T21513)
-Acer,Nitro N50-600
-
 # Massive graphics corruption (940MX) (T23366)
 Acer,TravelMate P648-G2-MG


### PR DESCRIPTION
Tested with new nvidia driver 418.43 and Linux kernel 5.0.0+, which fix
the original suspend & resume issue on Acer Nitro N50-600 equipped with
NVIDIA GTX 1060.  Besides, we also need the new nvidia driver to be
loaded for the new NVIDIA cards like RTX 2070.  So, this patch removes
Acer Nitro N50-600 on the black list.

https://phabricator.endlessm.com/T25980

Fixes: commit 179baa7b5783 (nvidia: prevent loading on Acer Nitro N50-600)