### PR TITLE
eos-preset: disable crio-shutdown, too

### DIFF
--- a/50-eos.preset
+++ b/50-eos.preset
@@ -13,6 +13,7 @@ disable apt-daily.timer
 disable apt-daily-upgrade.timer
 disable bluetooth-init.service
 disable crio.service
+disable crio-shutdown.service
 disable eos-factory-reset-users.service
 disable eos-firewall-localonly.service
 disable eos-update-server.service


### PR DESCRIPTION
This unit is harmless in and of itself, but it Wants=crio.service and is WantedBy=multi-user.target, meaning that the previous change to disable crio.service (6989c7b / #265) is ineffective.

https://phabricator.endlessm.com/T25542