### PR TITLE
eos.preset: disable eos-safe-defaults unit by default

### DIFF
--- a/50-eos.preset
+++ b/50-eos.preset
@@ -16,6 +16,7 @@ disable crio.service
 disable crio-shutdown.service
 disable eos-factory-reset-users.service
 disable eos-firewall-localonly.service
+disable eos-safe-defaults.service
 disable eos-update-server.service
 disable eos-update-server.socket
 disable eos-updater-avahi.path


### PR DESCRIPTION
We don't want the family-safe default settings to be enabled unless the systemd
unit is explicitly enabled in the image builder.

https://phabricator.endlessm.com/T23464