### PR TITLE
Revert "nvidia: unblacklist Acer Nitro N50-600"

### DIFF
--- a/nvidia/dmi-blacklist
+++ b/nvidia/dmi-blacklist
@@ -5,5 +5,8 @@
 # delimiter: ,
 # Quote character: "
 
+# Occasional hang upon S3 resume (GTX1060) (T21513)
+Acer,Nitro N50-600
+
 # Massive graphics corruption (940MX) (T23366)
 Acer,TravelMate P648-G2-MG


### PR DESCRIPTION
This reverts commit 56df1d3247b5e6182b7ea4dc2e0362ca918b4aa5.

This is believed to have been merged for nexthw support, on the
assumption that there would be no other EOS 3.5.x released. Turns out we
need an emergency release for Endless Hack, so I'm reverting this change
to avoid a regression of T21513.

https://phabricator.endlessm.com/T26629