### PR TITLE
 eos-update-flatpak-repos: avoid rewriting exports un-necessarily

### DIFF
--- a/eos-update-flatpak-repos
+++ b/eos-update-flatpak-repos
@@ -1225,7 +1225,7 @@ FLATPAK_METADATA_BUS_POLICY_OWN = 'own'
 FLATPAK_METADATA_GROUP_EXTRA_DATA = 'Extra Data'
 
 
-def rewrite_app_id(repo, mtree, old_id, new_id):
+def rewrite_metadata(repo, mtree, old_id, new_id):
     metadata, info = mtree_load_keyfile(repo, mtree, FLATPAK_METADATA_FILE)
     metadata.set_string(FLATPAK_METADATA_APPLICATION,
                         FLATPAK_METADATA_KEY_NAME, new_id)
@@ -1250,6 +1250,10 @@ def rewrite_app_id(repo, mtree, old_id, new_id):
             raise
 
     metadata_str = mtree_add_keyfile(repo, mtree, metadata, info)
+
+    if old_id == new_id:
+        vendor_prefixes = frozenset()
+        return metadata_str, vendor_prefixes
 
     dirs = mtree.get_subdirs()
     if 'export' in dirs:
@@ -1343,7 +1347,8 @@ def copy_commit(repo, src_rev, dest_ref,
 
     if old_app_id and new_app_id and \
        (old_app_id != new_app_id or migrate_extra):
-        metadata, vendor_prefixes = rewrite_app_id(repo, mtree, old_app_id, new_app_id)
+        metadata, vendor_prefixes = rewrite_metadata(repo, mtree, old_app_id,
+                                                     new_app_id)
         commit_metadata.insert_value('xa.metadata',
                                      GLib.Variant('s', metadata))
 

--- a/tests/test_update_flatpak_repos.py
+++ b/tests/test_update_flatpak_repos.py
@@ -137,7 +137,7 @@ class TestMangleMetadataAndDesktopFile(BaseTestCase):
         kde4_path = ('export', 'share', 'applications', 'kde4')
         self._put_file(kde4_path, orig_id + ".desktop", orig_data)
 
-        metadata_str, vendor_prefixes = eufr.rewrite_app_id(
+        metadata_str, vendor_prefixes = eufr.rewrite_metadata(
             self.repo, self.mtree, "com.example.Hello", "org.example.Hi",
         )
         self.assertEqual({'kde4'}, vendor_prefixes)
@@ -185,7 +185,7 @@ class TestMangleMetadataAndDesktopFile(BaseTestCase):
         # Pop an empty export dir in, to suppress a (legit) warning
         self._mkdir_p(('export',))
 
-        metadata_str, vendor_prefixes = eufr.rewrite_app_id(
+        metadata_str, vendor_prefixes = eufr.rewrite_metadata(
             self.repo, self.mtree, orig_id, expected_id,
         )
         self.assertEqual(set(), vendor_prefixes)
@@ -247,7 +247,7 @@ class TestMangleMetadataAndDesktopFile(BaseTestCase):
         desktop_path = ('export', 'share', 'applications')
         self._put_file(desktop_path, orig_name, orig_data)
 
-        metadata_str, vendor_prefixes = eufr.rewrite_app_id(
+        metadata_str, vendor_prefixes = eufr.rewrite_metadata(
             self.repo, self.mtree, orig_id, expected_id,
         )
         self.assertEqual(set(), vendor_prefixes)

--- a/tests/test_update_flatpak_repos.py
+++ b/tests/test_update_flatpak_repos.py
@@ -200,6 +200,61 @@ class TestMangleMetadataAndDesktopFile(BaseTestCase):
         # TODO: test the end-to-end migration process, including copying the
         # old extra data into place
 
+    def test_remove_extra_data(self):
+        """Tests that the Extra Data section is stripped from the metadata but
+        that the desktop file is left intact, even if there is no rename."""
+        orig_id = "com.example.Hello"
+
+        # Generate metadata file, store it in the tree
+        orig_metadata = textwrap.dedent(
+            """
+            [Application]
+            name=com.example.Hello
+            runtime=org.freedesktop.Platform/x86_64/18.08
+            sdk=org.freedesktop.Sdk/x86_64/18.08
+            command=hello
+
+            [Extra Data]
+            name=skypeforlinux-64.deb
+            checksum=e017fa5f3b78104b18c9e3ec00a678e513095cd4129a83b301f2b2c0dbb606a5
+            size=73441958
+            uri=https://repo.skype.com/deb/pool/main/s/skypeforlinux/skypeforlinux_8.34.0.78_amd64.deb
+            """
+        ).strip()
+        self._put_file((), "metadata", orig_metadata)
+
+        # Generate .desktop file, store it in the tree
+        orig_name = orig_id + '.desktop'
+        orig_desktop = textwrap.dedent(
+            """
+            [Desktop Entry]
+            """
+        ).strip()
+        desktop_path = ('export', 'share', 'applications')
+        self._put_file(desktop_path, orig_name, orig_desktop)
+
+        metadata_str, vendor_prefixes = eufr.rewrite_metadata(
+            self.repo, self.mtree, orig_id, orig_id,
+        )
+        self.assertEqual(set(), vendor_prefixes)
+
+        # Check the metadata name is unchanged
+        metadata = self._get_metadata()
+        self.assertEqual(metadata.get_string('Application', 'name'), orig_id)
+
+        # and that the Extra Data section has been removed
+        self.assertFalse(metadata.has_group('Extra Data'))
+
+        # Check the applications/ subdirectory still has the .desktop file
+        files = self._mkdir_p(desktop_path).get_files()
+        self.assertEqual(list(files.keys()), [orig_name])
+
+        # and that the contents are unchanged
+        _, stream, info, _ = self.repo.load_file(files[orig_name])
+        bytes_ = stream.read_bytes(info.get_size())
+        self.assertEqual(bytes_.get_data().decode("utf-8").strip(),
+                         orig_desktop)
+
     def _mkdir_p(self, path):
         mtree = self.mtree
         for name in path:


### PR DESCRIPTION
047f46b introduced the idea of unconditionally rewriting the metadata in the case that the app being migrated is an extra data app, previously only done when the app ID was changing. Unfortunately this exposed a bug in the rewriting of exports which causes the file handling to fail when the new and old ID are the same. Avoid entering this code path if the app IDs are the same, and add a test case to ensure that the desired behaviour is achieved. (Manual testing with the relevant hunk removed from the patch shows that the new test did indeed fail without this change.)

https://phabricator.endlessm.com/T26588