### PR TITLE
eos-update-flatpak-repos: Migrate BillardGL from eos-apps to flathub

### DIFF
--- a/eos-update-flatpak-repos
+++ b/eos-update-flatpak-repos
@@ -1050,6 +1050,15 @@ FLATPAKS_TO_MIGRATE = [
         'new-branch': 'stable',
         'old-origin': 'eos-apps',
         'new-origin': 'flathub'
+    },
+    # migrate BillardGL from eos-apps to flathub (T27078)
+    {
+        'name': 'de.billardgl.Billardgl',
+        'kind': Flatpak.RefKind.APP,
+        'old-branch': 'eos3',
+        'new-branch': 'stable',
+        'old-origin': 'eos-apps',
+        'new-origin': 'flathub'
     }
 ]
 


### PR DESCRIPTION
https://phabricator.endlessm.com/T27078