### PR TITLE
endless-repartition: Check for root fsck service in generator.late too

### DIFF
--- a/dracut/repartition/endless-repartition.sh
+++ b/dracut/repartition/endless-repartition.sh
@@ -246,9 +246,16 @@ EOF
 # we must double up the backslashes first.
 orig_root_part_escaped=$(systemd-escape -p $orig_root_part | sed -e 's:\\:\\\\:g')
 root_part_escaped=$(systemd-escape -p $root_part | sed -e 's:\\:\\\\:g')
+
+#for PAYG images using sd-boot, this ends up in generator.late
+if [ -a /run/systemd/generator/systemd-fsck-root.service ] ;then
+  service_file=/run/systemd/generator/systemd-fsck-root.service
+else
+  service_file=/run/systemd/generator.late/systemd-fsck-root.service
+fi
 sed -e "s:$orig_root_part:$root_part:" \
   -e "s:$orig_root_part_escaped:$root_part_escaped:" \
-  /run/systemd/generator/systemd-fsck-root.service \
+  "$service_file" \
   > /etc/systemd/system/systemd-fsck-root.service
 
 # Make systemd aware of the unit file changes


### PR DESCRIPTION
When booting with systemd-boot and auto mounting the ESP, the service
file to fsck the root fs ends up in generator.late instead of
generator, leading to a failure on the first boot after install.

Look in both places to increase chances of success.

https://phabricator.endlessm.com/T27041