### PR TITLE
image-boot: alternative method for seeding machine-id in overlay

### DIFF
--- a/eos-live-boot-overlayfs-setup
+++ b/eos-live-boot-overlayfs-setup
@@ -46,47 +46,30 @@ setup_ostree_flatpak_overlay() {
 
 setup_overlay() {
     local dir=$1
-    local target=${2:-/$dir}
     [ -d /$dir ] || return
-    [ -d /run/eos-live/$dir ] && return
     # If the directory is a symlink, assume it's pointing to a location
     # covered by another top level overlay
     [ -L /$dir ] && return
     mkdir -p /run/eos-live/$dir /run/eos-live/$dir-workdir
     mount -t overlay -o \
         rw,upperdir=/run/eos-live/$dir,lowerdir=/$dir,workdir=/run/eos-live/$dir-workdir \
-        eos-live-$dir $target
+        eos-live-$dir /$dir
 }
-
-# Setup /etc overlay at a special temporary location first, so that we can
-# atomically take care of /etc/machine-id presence.
-mkdir /run/etc.tmp
-setup_overlay etc /run/etc.tmp
 
 # If we booted and systemd was unable to find or create a machine-id,
 # it will create one at /run/machine-id and bind mount it at /etc/machine-id.
-# But the overlay we just set up at /run/etc.tmp does not include that child
-# bind mount, so in the case where this is a brand new empty overlay, we're
-# back to having no machine-id there.
+# But when we create the /etc overlay, we will lose that bind mount.
 #
-# In addition to recovering the machine-id, we also want to use this
-# opportunity to store it in the overlayfs, in case the overlayfs is backed
-# by persistent storage.
-#
-# Both goals can be satisfied in simplistic fashion by copying systemd's
-# boot-generated machine-id into place, in the case where we didn't find one
-# in the overlay.
-
-if [[ ! -s /run/etc.tmp/machine-id && -s /run/machine-id ]]; then
-  cp /run/machine-id /run/etc.tmp/machine-id
+# Here we create the overlay upperdir in advance, pre-seeding systemd's
+# boot-generated machine-id before we create the overlay. This way, we avoid
+# any points during the transition where /etc/machine-id is missing.
+mkdir -p /run/eos-live/etc
+if [[ -s /run/machine-id ]]; then
+  cp /run/machine-id /run/eos-live/etc/machine-id
 fi
 
-# Atomically move our /etc overlay into the right place
-mount --move /run/etc.tmp /etc
-rmdir /run/etc.tmp
-
-# Everything else but /sysroot/{ostree,flatpak} is pretty straightforward:
-overlay_dirs="bin boot endless home lib opt ostree root sbin srv sysroot/home var"
+# Everything but /sysroot/{ostree,flatpak} is pretty straightforward:
+overlay_dirs="etc bin boot endless home lib opt ostree root sbin srv sysroot/home var"
 for dir in $overlay_dirs $EXTRA_PATHS; do
     setup_overlay $dir
 done


### PR DESCRIPTION
The approach attempted in commit 4d348fb9b56ff34cf150d68a6012b6ce5778d51a
didn't work because the parent mount at /run is a shared mount, and
mount --move cannot be used there.

There isn't an existing clear place in the hierarchy where we can work
with private mounts instead, so just change the approach, instead
populating the overlayfs upperdir in advance.

This will need tweaking when we implement support for persistent overlayfs
storage (and that's also true for other code in this file).

https://phabricator.endlessm.com/T27158