### PR TITLE
endless-repartition: Fix up ESP UUID EFI variable for PAYG

### DIFF
--- a/dracut/repartition/module-setup.sh
+++ b/dracut/repartition/module-setup.sh
@@ -16,6 +16,8 @@ install() {
   dracut_install mkswap
   dracut_install sed
   dracut_install tune2fs
+  dracut_install chattr
+  dracut_install iconv
   dracut_install -o amlogic-fix-spl-checksum
   inst_script "$moddir/endless-repartition.sh" /bin/endless-repartition
   inst_simple "$moddir/endless-repartition.service" \


### PR DESCRIPTION
systemd-boot passes us the ESP's UUID in an EFI variable, and
systemd will only mount the ESP if the UUID on disk matches the one
systemd-boot passed.

When we repartition all the UUIDs change, so update the variable
to match so the first boot properly mounts the ESP.

https://phabricator.endlessm.com/T27041