### PR TITLE
endless-repartition: Fix up ESP UUID EFI variable for PAYG again

### DIFF
--- a/dracut/repartition/endless-repartition.sh
+++ b/dracut/repartition/endless-repartition.sh
@@ -236,7 +236,7 @@ if [ -f "${esp_var}" ]; then
   chattr -i ${esp_var}
   #We need to start with 0x06 0x00 0x00 0x00 and end with 0x00 0x00
   #iconv will add the extra 0s
-  printf "\06\00"${new_esp_uuid}"\00" | iconv -f ascii -t unicodelittle > ${esp_var}
+  printf "\060\000"${new_esp_uuid}"\000" | iconv -f ascii -t unicodelittle > ${esp_var}
   chattr +i ${esp_var}
 fi
 


### PR DESCRIPTION
UUIDs are hex numbers, and when they start with a decimal digit, eg 1
the printf becomes: printf \06\001
that's 0x06 0x01 which is not at all the intended 0x06 0x00 0x31

Switch all the octal to 3 digit (as an aside, the shell used doesn't
support hex notation, which is why we're using octal)

https://phabricator.endlessm.com/T27041