### PR TITLE
endless-repartition: Update loader efi var so it works on real computers

### DIFF
--- a/dracut/repartition/module-setup.sh
+++ b/dracut/repartition/module-setup.sh
@@ -16,7 +16,6 @@ install() {
   dracut_install mkswap
   dracut_install sed
   dracut_install tune2fs
-  dracut_install chattr
   dracut_install iconv
   dracut_install -o amlogic-fix-spl-checksum
   inst_script "$moddir/endless-repartition.sh" /bin/endless-repartition


### PR DESCRIPTION
Overwriting the LoaderDevicePart variable doesn't work on all EFI
firmware implementations. Some (including tianocore, where this
behaviour can be verified by inspection in Variable.c) don't allow
volatile variables to be altered in any way at run time.

It works on VirtualBox, where I've been testing this code, but not
on any of the physical hardware I've tried on.

Instead of writing downstream hacks into systemd to make this work,
bind mount our chosen variable contents over the file we can't change.
This leaves a harmless bind mount lying around on the first boot -
this can be seen in 'df' output.

https://phabricator.endlessm.com/T27041