### PR TITLE
 image-boot: Create partition for persistent data storage 

### DIFF
--- a/dracut/image-boot/Makefile.am
+++ b/dracut/image-boot/Makefile.am
@@ -2,6 +2,7 @@ dracutmoddir = $(prefix)/lib/dracut/modules.d/50eos-image-boot
 dist_dracutmod_SCRIPTS = \
 	eos-image-boot-generator \
 	eos-image-boot-setup \
+	eos-live-storage-setup \
 	eos-map-image-file \
 	module-setup.sh \
 	$(NULL)

--- a/dracut/image-boot/eos-image-boot-generator
+++ b/dracut/image-boot/eos-image-boot-generator
@@ -25,10 +25,6 @@ mkdir -p /run/udev/rules.d
 echo 'SUBSYSTEM=="block", ENV{ID_FS_TYPE}=="iso9660", GOTO="skip_ignore"' > /run/udev/rules.d/79-endless-image-device.rules
 
 case "${image_device}" in
-PARTUUID=*)
-  echo "SUBSYSTEM==\"block\", ENV{ID_PART_ENTRY_UUID}==\"${image_device#PARTUUID=}\", ENV{DM_NAME}!=\"endless-image-device\", ENV{UDISKS_IGNORE}=\"1\"" >> /run/udev/rules.d/79-endless-image-device.rules
-  image_device=/dev/disk/by-partuuid/${image_device#PARTUUID=}
-  ;;
 UUID=*)
   echo "SUBSYSTEM==\"block\", ENV{ID_FS_UUID}==\"${image_device#UUID=}\", ENV{DM_NAME}!=\"endless-image-device\", ENV{UDISKS_IGNORE}=\"1\"" >> /run/udev/rules.d/79-endless-image-device.rules
   image_device=/dev/disk/by-uuid/${image_device#UUID=}
@@ -41,10 +37,13 @@ echo 'LABEL="skip_ignore"' >> /run/udev/rules.d/79-endless-image-device.rules
 
 image_device_escaped=$(systemd-escape -p "${image_device}")
 
-# For convenience so that other scripts don't have to parse the cmdline again
-echo "${image_device}" > /var/tmp/endless-image-host
-
-# When the image device appears, run the setup
+# When the image device appears, run the setup.
+# Note that when booting an ISO using HD emulation (e.g. booting an ISO file
+# flashed to USB), udev records that the ISO UUID applies to both the iso9660
+# data partition *and* the parent disk node. So it's a little unwise to
+# rely on the /dev/disk/by-uuid symlink, but it's good enough as a way
+# of ensuring that the overall device has appeared.
+# eos-image-boot-setup will then deal with the UUID clash problem.
 mkdir -p ${GENERATOR_DIR}/initrd-fs.target.wants
 ln -s /lib/systemd/system/eos-image-boot-setup.service \
 	${GENERATOR_DIR}/initrd-fs.target.wants

--- a/dracut/image-boot/eos-image-boot-setup
+++ b/dracut/image-boot/eos-image-boot-setup
@@ -43,6 +43,9 @@ else
 
   blockdev --setro ${host_device}
 
+  # If possible, create partition for persistent data storage
+  eos-live-storage-setup "${host_device}"
+
   if getargbool 0 endless.live_boot; then
     dm_roflag=--readonly
     kpartx_roflag=-r

--- a/dracut/image-boot/eos-image-boot-setup
+++ b/dracut/image-boot/eos-image-boot-setup
@@ -20,11 +20,27 @@ if [ $# -ge 1 ]; then
 else
   type getarg >/dev/null 2>&1 || . /lib/dracut-lib.sh
 
-  host_device=$(cat /var/tmp/endless-image-host)
+  image_device=$(getarg endless.image.device)
   image_path=$(getarg endless.image.path)
   target_name=endless-image
 
+  # When booting an ISO using HD emulation (e.g. booting an ISO file flashed
+  # to USB), udev records that the ISO UUID applies to both the iso9660
+  # data partition *and* the parent disk node. So we have to be careful
+  # when finding host_device.
+
+  # Let udev finish probing all the partitions
   udevadm settle
+
+  # To find the data partition, we take advantage of blkid which limits
+  # itself to only searching devices with recognised filesystems. It will
+  # avoid the parent disk node here.
+  host_device=$(blkid --uuid "${image_device#UUID=}")
+  if [ -z "${host_device}" ]; then
+    echo "Failed to find host partition device"
+    exit 1
+  fi
+
   blockdev --setro ${host_device}
 
   if getargbool 0 endless.live_boot; then

--- a/dracut/image-boot/eos-live-storage-setup
+++ b/dracut/image-boot/eos-live-storage-setup
@@ -1,0 +1,98 @@
+#!/bin/sh
+# Copyright (C) 2019 Endless Mobile, Inc.
+# Licensed under the GPLv2
+#
+# When performing a live boot, create a 3rd partition filling the remaining
+# space on the device. This partition will later be used for persistent data
+# storage, so that your documents are kept for next time you boot.
+#
+# The filesystem is not created here (within the initramfs) as that can be
+# deferred until we are running from the real root. We just write a textual
+# marker to the start of the partition to indicate that the partition is
+# pending filesystem creation.
+
+image_partition_dev=$(readlink -f "$1")
+image_partition_type=$(lsblk -d -n -o TYPE "${image_partition_dev}")
+image_partition_sysfs=/sys/class/block/$(lsblk -d -n -o KNAME "${image_partition_dev}")
+
+if [ "${image_partition_type}" = "rom" ]; then
+  echo "Skipping storage setup - read only media"
+  exit 0
+fi
+
+case ${image_partition_dev} in
+  *1)
+    # partition 1 - ok
+    ;;
+  *)
+    echo "Skipping storage setup as image is not on partition 1"
+    exit 0
+    ;;
+esac
+
+case ${image_partition_dev} in
+  /dev/loop*p?)
+    using_loop=1
+    ;;
+esac
+
+host_disk_dev=/dev/$(lsblk -d -n -o PKNAME "${image_partition_dev}")
+host_disk_size=$(blockdev --getsz "${host_disk_dev}")
+
+# Identify EFI partition, which precedes the partition we will create
+efi_partition_dev=${image_partition_dev%?}2
+[ -e "${efi_partition_dev}" ] || exit 0
+
+efi_partition_sysfs=/sys/class/block/$(lsblk -d -n -o KNAME "${efi_partition_dev}")
+efi_partition_start=$(cat "${efi_partition_sysfs}"/start)
+efi_partition_size=$(blockdev --getsz "${efi_partition_dev}")
+[ -z "${efi_partition_start}" ] && exit 1
+
+# Set up target storage partition
+storage_partition_dev=${image_partition_dev%?}3
+[ -e "${storage_partition_dev}" ] && exit 0
+
+# Find a start position after the EFI partition
+storage_partition_start=$(( efi_partition_start + efi_partition_size ))
+
+# Fill the remainder of the disk
+storage_partition_size=$(( host_disk_size - storage_partition_start ))
+
+# Only create a storage partition if we have more than 1GB available,
+# otherwise assume that live mode is preferable.
+if [ ${storage_partition_size} -lt 2097152 ]; then
+  echo "Skip partition creation ($storage_partition_size sectors available)"
+  exit 0
+fi
+
+# Align storage partition start to 1MB boundary
+residue=$(( storage_partition_start % 2048 ))
+if [ $residue -gt 0 ]; then
+  storage_partition_start=$(( storage_partition_start + 2048 - residue ))
+  storage_partition_size=$(( host_disk_size - storage_partition_start ))
+fi
+
+# Just in case we ever want to convert to GPT, reserve 33 sectors at the
+# end of the disk, big enough for the secondary GPT header
+storage_partition_size=$(( storage_partition_size - 33 ))
+
+# udev might still be busy probing the disk, meaning that it will be in use.
+udevadm settle
+
+# Apply partition table change
+echo "start=${storage_partition_start}" |
+  sfdisk --no-reread --append "${host_disk_dev}"
+ret=$?
+echo "sfdisk returned $ret"
+udevadm settle
+
+# Loop devices need a prod for the new partition to show up
+if [ -n "${using_loop}" ]; then
+  partprobe "$host_disk_dev"
+  udevadm settle
+fi
+
+# write marker bytes to new partition, to trigger filesystem creation
+# later during boot
+echo "endless_live_storage_marker" > ${storage_partition_dev}
+exit 0

--- a/dracut/image-boot/eos-live-storage-setup
+++ b/dracut/image-boot/eos-live-storage-setup
@@ -2,7 +2,7 @@
 # Copyright (C) 2019 Endless Mobile, Inc.
 # Licensed under the GPLv2
 #
-# When performing a live boot, create a 3rd partition filling the remaining
+# When performing a live boot from an ISO image on a writeable medium, create a 3rd partition filling the remaining
 # space on the device. This partition will later be used for persistent data
 # storage, so that your documents are kept for next time you boot.
 #

--- a/dracut/image-boot/module-setup.sh
+++ b/dracut/image-boot/module-setup.sh
@@ -14,6 +14,7 @@ install() {
   instmods overlay
   inst_rules 55-dm.rules 60-cdrom_id.rules 95-dm-notify.rules
   inst_script "$moddir"/eos-image-boot-setup /bin/eos-image-boot-setup
+  inst_script "$moddir"/eos-live-storage-setup /bin/eos-live-storage-setup
   inst_script "$moddir"/eos-map-image-file /bin/eos-map-image-file
   inst_simple "$moddir"/eos-image-boot-setup.service \
 	"$systemdsystemunitdir"/eos-image-boot-setup.service

--- a/tests/test_image_boot.py
+++ b/tests/test_image_boot.py
@@ -17,7 +17,6 @@ from .util import (
     losetup,
     mount,
     needs_root,
-    partprobe,
     sfdisk,
     system_script,
     udevadm_settle,
@@ -40,15 +39,13 @@ class ImageTestCase(BaseTestCase):
             sfdisk(host_img.name, b'start=64KiB, type=0x07')
 
             with losetup(host_img.name) as host_disk:
-                partprobe(host_disk)
-                udevadm_settle()
-
                 host_device = host_disk + 'p1'
                 subprocess.check_call([mkfs, host_device])
-                partprobe(host_disk)
-                udevadm_settle()
-                self.assert_fstype(host_device, filesystem)
 
+                # Wait for udev to probe new filesystem type
+                udevadm_settle()
+
+                self.assert_fstype(host_device, filesystem)
                 yield host_device
 
     def assert_readonly(self, device, readonly):

--- a/tests/test_live_storage.py
+++ b/tests/test_live_storage.py
@@ -1,0 +1,140 @@
+#!/usr/bin/python3
+'''
+Tests eos-live-storage-setup. Must be run as a user privileged enough to run
+`losetup`. If run as an unprivileged user, all tests are skipped.
+'''
+from contextlib import contextmanager
+from subprocess import check_call, check_output, CalledProcessError
+import re
+import tempfile
+
+from .util import (
+    BaseTestCase,
+    dracut_script,
+    losetup,
+    needs_root,
+    sfdisk,
+)
+
+
+EOS_LIVE_STORAGE_SETUP = dracut_script('image-boot', 'eos-live-storage-setup')
+DISK_SIZE_BYTES = 4 * (1024 ** 3)
+STANDARD_PARTITION_TABLE = '''
+label: dos
+unit: sectors
+label-id: 0xdeadbeef
+
+start=        2048, size=     4251900, type=0, bootable
+start=     4255996, size=       28672, type=ef
+'''.strip().encode('ascii')  # noqa: E501
+
+
+@contextmanager
+def _prepare(initial_table):
+    with tempfile.NamedTemporaryFile(buffering=0) as img:
+        img.truncate(DISK_SIZE_BYTES)
+        sfdisk(img.name, initial_table)
+
+        with losetup(img.name) as img_device:
+            yield img, img_device
+
+class TestLiveStorage(BaseTestCase):
+    @needs_root
+    def test_data_partition_added(self):
+        with _prepare(STANDARD_PARTITION_TABLE) as (img, img_device):
+            try:
+                check_call([EOS_LIVE_STORAGE_SETUP, img_device + "p1"])
+
+                new_table = check_output(["sfdisk", "--dump", img_device],
+                                         universal_newlines=True)
+                expected_table = '''
+label: dos
+label-id: 0xdeadbeef
+device: {img_device}
+unit: sectors
+
+{img_device}p1 : start=        2048, size=     4251900, type=0, bootable
+{img_device}p2 : start=     4255996, size=       28672, type=ef
+{img_device}p3 : start=     4286464, size=     4102144, type=83
+                    '''.strip().format(img_device=img_device)
+
+                # Check that data partition was added as expected
+                # Note that the values above also ensure that the data partition was
+                # aligned to a 1mb boundary, leaving a few unused sectors after p2.
+                self.assertEqual(expected_table, new_table.strip())
+
+                # Check that the marker was written
+                with open(img_device + "p3", "r") as fd:
+                    self.assertEqual(fd.read(27),
+                                     "endless_live_storage_marker")
+            except Exception:
+                # Log the current state to aid debugging
+                check_call(["sfdisk", "--dump", img_device])
+                raise
+
+    # Test that no action is taken if we already have 3 partitions
+    @needs_root
+    def test_already_have_data_partition(self):
+        table = '''
+start=        2048, size=     4251900, type=0, bootable
+start=     4255996, size=       28672, type=ef
+size=65536, type=83
+'''.strip().encode('ascii')  # noqa: E501
+        with _prepare(table) as (img, img_device):
+            try:
+                orig_table = check_output(["sfdisk", "--dump", img_device],
+                                         universal_newlines=True)
+
+                check_call([EOS_LIVE_STORAGE_SETUP, img_device + "p1"])
+
+                new_table = check_output(["sfdisk", "--dump", img_device],
+                                         universal_newlines=True)
+                self.assertEqual(orig_table, new_table)
+            except Exception:
+                # Log the current state to aid debugging
+                check_call(["sfdisk", "--dump", img_device])
+                raise
+
+    # Test that no action is taken if the disk was already completely full
+    @needs_root
+    def test_no_space_available(self):
+        table = '''
+start=        2048, size=     4251900, type=0, bootable
+start=     4255996, type=ef
+'''.strip().encode('ascii')  # noqa: E501
+        with _prepare(table) as (img, img_device):
+            try:
+                orig_table = check_output(["sfdisk", "--dump", img_device],
+                                         universal_newlines=True)
+
+                check_call([EOS_LIVE_STORAGE_SETUP, img_device + "p1"])
+
+                new_table = check_output(["sfdisk", "--dump", img_device],
+                                         universal_newlines=True)
+                self.assertEqual(orig_table, new_table)
+            except Exception:
+                # Log the current state to aid debugging
+                check_call(["sfdisk", "--dump", img_device])
+                raise
+
+    # Test that no action is taken if the disk doesn't have much space left
+    @needs_root
+    def test_not_much_space_available(self):
+        table = '''
+start=        2048, size=     4251900, type=0, bootable
+start=     4255996, size=     4130000, type=ef
+'''.strip().encode('ascii')  # noqa: E501
+        with _prepare(table) as (img, img_device):
+            try:
+                orig_table = check_output(["sfdisk", "--dump", img_device],
+                                         universal_newlines=True)
+
+                check_call([EOS_LIVE_STORAGE_SETUP, img_device + "p1"])
+
+                new_table = check_output(["sfdisk", "--dump", img_device],
+                                         universal_newlines=True)
+                self.assertEqual(orig_table, new_table)
+            except Exception:
+                # Log the current state to aid debugging
+                check_call(["sfdisk", "--dump", img_device])
+                raise

--- a/tests/test_reclaim_swap.py
+++ b/tests/test_reclaim_swap.py
@@ -14,7 +14,7 @@ from .util import (
 
 
 EOS_RECLAIM_SWAP = system_script('eos-reclaim-swap')
-DATA_DIR = './data/reclaim-swap'
+DATA_DIR = os.path.dirname(os.path.realpath(__file__)) + '/data/reclaim-swap'
 
 
 class TestReclaimSwap(BaseTestCase):

--- a/tests/util.py
+++ b/tests/util.py
@@ -81,10 +81,13 @@ def losetup(path):
 
     device = output.decode('utf-8').strip()
     try:
-        partprobe(device)
+        subprocess.call(['partx', '-a', device])
+        udevadm_settle()
         yield device
     finally:
+        subprocess.call(['partx', '-d', device])
         subprocess.check_call(['losetup', '--detach', device])
+        udevadm_settle()
 
 
 class BaseTestCase(unittest.TestCase):


### PR DESCRIPTION
In order to add persistent data storage capabilities to our
live+installer setup (so that you don't lose your data on reboot),
add another step in the boot process that creates the partition.

Similar to the repartitioning case for first-boot of installed systems,
this must be done in the initramfs, before any filesystems are mounted,
so that the kernel is able to update it's view of the partition table
without requiring a reboot.

Even though there are some similarities to endless-repartition.sh, the
actual details are quite different so I found it more appropriate to
implement as a separate script.

The actual filesystem creation is deferred to the boot from the "real
root" and will be handled separately.

https://phabricator.endlessm.com/T27158