### PR TITLE
eos-preset: Disable smartd.service

### DIFF
--- a/50-eos.preset
+++ b/50-eos.preset
@@ -28,6 +28,7 @@ disable openvpn.service
 disable openvpn@.service
 disable rtkit-daemon.service
 disable serial-getty@.service
+disable smartd.service
 disable speech-dispatcherd.service
 disable ssh*.service
 disable ssh.socket


### PR DESCRIPTION
smartmontools was added for some hardware tests from Checkbox, and does
not need to be running in the OS. It currently fails to start on OpenQA
and eMMC-only devices with the following error:

 smartd[1958]: DEVICESCAN failed: glob(3) aborted matching pattern /dev/discs/disc*
 smartd[1958]: In the system's table of devices NO devices found to scan

https://phabricator.endlessm.com/T27837