### PR TITLE
live-boot: create flatpak overlayfs on subsequent boots too

### DIFF
--- a/eos-live-boot-overlayfs-setup
+++ b/eos-live-boot-overlayfs-setup
@@ -75,7 +75,6 @@ setup_ostree_flatpak_overlay() {
     local lowerdir=/sysroot/ostree:/sysroot/flatpak
     local upperdir=/run/eos-live/ostree-flatpak
     local workdir=$upperdir-workdir
-    [ -d $workdir ] && return;
     mkdir -p $upperdir $workdir
     mount -t overlay -o \
         rw,upperdir=$upperdir,lowerdir=$lowerdir,workdir=$workdir \


### PR DESCRIPTION
Now that /run/eos-live has persistent backing storage for
ISO USB boots, we need to go ahead and create this overlayfs
even when the upperdir already exists.

Otherwise the flatpak setup is only done on first boot, but not on
any subsequent boots of this media, and you can't launch your flatpak
apps as a result.

https://phabricator.endlessm.com/T27771