### PR TITLE
hack: Add new service to remove the global override

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -23,6 +23,7 @@ dist_systemdunit_DATA = \
 	eos-live-boot-overlayfs-setup.service \
 	eos-reclaim-swap.service \
 	eos-update-flatpak-repos.service \
+	hack-remove-global-override.service \
 	$(NULL)
 
 dist_systemdgenerator_SCRIPTS = \

--- a/hack-remove-global-override.service
+++ b/hack-remove-global-override.service
@@ -1,0 +1,21 @@
+[Unit]
+Description=Remove hack flatpak global override
+DefaultDependencies=no
+Conflicts=shutdown.target
+Wants=local-fs.target
+After=local-fs.target
+
+# Only run on updates
+Before=multi-user.target systemd-update-done.service eos-updater-flatpak-installer.service
+ConditionNeedsUpdate=|/etc
+ConditionNeedsUpdate=|/var
+
+ConditionPathExists=/var/lib/flatpak/overrides/global
+ConditionPathExists=/var/lib/flatpak/app/com.endlessm.HackComponents
+
+[Service]
+Type=oneshot
+ExecStart=/usr/bin/rm /var/lib/flatpak/overrides/global
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
Old hack computer has a global flatpak override file. In the new hack
experience we're going from using a custom product EOS to use the main
EOS branch so, we need to remove this global override and we'll use
local override for each application.

This patch adds a service that will remove the global override, only for
old hack-computer users, it checks for the HackComponents flatpak that
should only be installed in old hack computers, and if that exists it'll
remove the global override.

This service is based on the eos-update-flatpak-repos to be run only on
update.

https://phabricator.endlessm.com/T27984

## Here we've the steps to follow to test this:

 1. Place the systemd service in your system:

```
cp hack-remove-global-override.service /etc/systemd/system
```

2. You should need to have `com.endlessm.HackComponents`
3. Create the global override file if it doesn't exists in `/var/lib/flatpak/overrides/global`
4. Update your system and reboot! Then, after the reboot, the global override should be removed.

You can try to uninstall the `com.endlessm.HackComponents` and try again, in that case the global override won't be removed.

If it's hard to have a new system update you can modify the service to be run without the update replacing this lines:

```
# Only run on updates
Before=multi-user.target systemd-update-done.service
ConditionNeedsUpdate=|/etc
ConditionNeedsUpdate=|/var
```

and leaving only:

```
Before=multi-user.target
```