### PR TITLE
zram: Wait for zram0 to be ready before calling mkswap

### DIFF
--- a/eos-enable-zram
+++ b/eos-enable-zram
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/bin/bash
 # Copyright (C) 2018 Endless Mobile, Inc.
 # Licensed under the GPLv2
 
@@ -10,6 +10,7 @@ fi
 ram_size_kb=$(awk '/MemTotal/{print $2}' /proc/meminfo)
 
 if [ "$1" -ne 0 ]; then
+    set -e
     if [ ! -e /sys/block/zram0 ]; then
         modprobe zram
     fi

--- a/eos-enable-zram
+++ b/eos-enable-zram
@@ -15,6 +15,7 @@ if [ "$1" -ne 0 ]; then
         modprobe zram
     fi
     echo $(($ram_size_kb * 3 / 2))K > /sys/block/zram0/disksize
+    udevadm settle
     # For now, disable the swap partition if in use
     swapoff -a
     mkswap /dev/zram0

--- a/eos-enable-zram.service
+++ b/eos-enable-zram.service
@@ -7,7 +7,7 @@ After=swap.target
 Type=oneshot
 RemainAfterExit=true
 ExecStart=/usr/sbin/eos-enable-zram 1
-ExecStop=/usr/sbin/eos-enable-zram 0
+ExecStopPost=/usr/sbin/eos-enable-zram 0
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
Writing to the disksize attribute does not guarantee the device is ready
to be used. Calling udevadm settle makes the service wait for the device
to be ready before proceeding.

https://phabricator.endlessm.com/T28111