### PR TITLE
eos-update-flatpak-repos: migrate GNOME 3.22 runtime

### DIFF
--- a/eos-update-flatpak-repos
+++ b/eos-update-flatpak-repos
@@ -293,6 +293,13 @@ FLATPAKS_TO_MIGRATE = [
     {
         'prefix': 'org.gnome.',
         'kind': Flatpak.RefKind.RUNTIME,
+        'old-branch': '3.22',
+        'old-origin': 'gnome',
+        'new-origin': 'flathub'
+    },
+    {
+        'prefix': 'org.gnome.',
+        'kind': Flatpak.RefKind.RUNTIME,
         'old-branch': '3.24',
         'old-origin': 'gnome',
         'new-origin': 'flathub'


### PR DESCRIPTION
A speculative fix for the issue reported on
https://community.endlessos.com/t/no-se-ejecuta-steam-desde-hace-tiempo/10758.
This user has org.gnome.Platform//3.22 installed from the 'gnome'
remote, but does not have a 'gnome' remote, because the eos3.3 version
of this script forcibly deletes it.

https://phabricator.endlessm.com/T25809