### PR TITLE
eos-update-flatpak-repos: skip parental controls checks

### DIFF
--- a/eos-update-flatpak-repos.service
+++ b/eos-update-flatpak-repos.service
@@ -28,5 +28,10 @@ Type=oneshot
 RemainAfterExit=true
 ExecStart=/usr/sbin/eos-update-flatpak-repos
 
+# Flatpak checks parental controls at deploy time. In order to do this, it
+# needs to talk to accountsservice on the system bus, neither of which are
+# running when this job runs.
+Environment=FLATPAK_SKIP_PARENTAL_CONTROLS_NO_SYSTEM_BUS=1
+
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
Installing a Flatpak now involves talking to accountsservice, even if
running as root. Without this change, the script job fails with:

    ERROR:root:Failure applying migration to org.squeakland.Etoys
    Traceback (most recent call last):
      File "/usr/sbin/eos-update-flatpak-repos", line 1589, in _migrate_installed_flatpaks
        arch, new_branch)
    gi.repository.GLib.GError: g-io-error-quark: Could not connect: No such file or directory (1)

https://phabricator.endlessm.com/T28386