### PR TITLE
eos-update-flatpak-repos: Migrate GNOME 3.20 and fd.o 1.4

### DIFF
--- a/eos-update-flatpak-repos
+++ b/eos-update-flatpak-repos
@@ -282,11 +282,25 @@ FLATPAKS_TO_MIGRATE = [
         'old-origin': 'eos-apps',
         'new-origin': 'flathub'
     },
-    # migrate gnome 3.2[46] and freedesktop 1.6 runtimes to flathub (T20443)
+    # migrate gnome 3.2[02468] and freedesktop 1.[46] runtimes to flathub (T20443 and T25809)
+    {
+        'prefix': 'org.freedesktop.',
+        'kind': Flatpak.RefKind.RUNTIME,
+        'old-branch': '1.4',
+        'old-origin': 'gnome',
+        'new-origin': 'flathub'
+    },
     {
         'prefix': 'org.freedesktop.',
         'kind': Flatpak.RefKind.RUNTIME,
         'old-branch': '1.6',
+        'old-origin': 'gnome',
+        'new-origin': 'flathub'
+    },
+    {
+        'prefix': 'org.gnome.',
+        'kind': Flatpak.RefKind.RUNTIME,
+        'old-branch': '3.20',
         'old-origin': 'gnome',
         'new-origin': 'flathub'
     },


### PR DESCRIPTION
The now-retired "gnome" flatpak remote served org.gnome.Platform//3.20
and org.freedesktop.Platform//1.4, so there's some chance these exist on
some user's system, and are preventing that user from updating due to
https://phabricator.endlessm.com/T25809. So migrate them both to
Flathub. Flathub does not in fact serve those runtimes any more (or
ever?) but as long as they're not deployed from a remote that doesn't
exist, the update to 3.3.20 (yet to be released) and beyond should
succeed.

https://phabricator.endlessm.com/T25809