### PR TITLE
Allow persistent storage for combo usb sticks

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -86,6 +86,10 @@ dist_sbin_SCRIPTS = \
 	eos-update-flatpak-repos \
 	$(NULL)
 
+dist_libexec_SCRIPTS = \
+	dracut/image-boot/eos-map-image-file \
+	$(NULL)
+
 tmpfilesdir = $(prefix)/lib/tmpfiles.d
 dist_tmpfiles_DATA = \
 	tmpfiles.d/avahi-service-writers.conf \

--- a/dracut/image-boot/eos-map-image-file
+++ b/dracut/image-boot/eos-map-image-file
@@ -26,7 +26,7 @@ if [ "$#" != "3" ]; then
   exit 1
 fi
 
-if ! fstype=$(lsblk --noheadings -o FSTYPE "${host_device}"); then
+if ! fstype=$(lsblk --noheadings --nodeps -o FSTYPE "${host_device}"); then
   echo "image-boot: failed to detect filesystem type for ${host_device}" >&2
   exit 1
 fi

--- a/eos-image-boot-dm-setup.service
+++ b/eos-image-boot-dm-setup.service
@@ -4,6 +4,7 @@ DefaultDependencies=no
 After=ostree-remount.service
 Before=local-fs.target
 ConditionKernelCommandLine=endless.image.device
+ConditionKernelCommandLine=!endless.live_boot
 
 [Service]
 Type=oneshot

--- a/eos-live-boot-overlayfs-setup
+++ b/eos-live-boot-overlayfs-setup
@@ -8,7 +8,7 @@ EXTRA_PATHS=$@
 # user.
 mount -o remount,user_xattr /run
 
-# Attempt to find the partition to act as backing storage for the overlayfses
+# Attempt to find a target to act as backing storage for the overlayfses
 find_storage_partition() {
 	local bootdev=$(grep -oP "endless\.image\.device=UUID=[^ ]+" /proc/cmdline)
 	bootdev=${bootdev:21}
@@ -16,6 +16,17 @@ find_storage_partition() {
 
 	local root_partition=$(blkid --output device --match-token "${bootdev}")
 	[ -b "${root_partition}" ] || return 1
+
+
+	dumpexfat -f /endless/persistent.img ${root_partition} &> /dev/null
+	if [[ $? = 0 ]]; then
+		udevadm settle
+		/usr/libexec/eos-map-image-file ${root_partition} /endless/persistent.img endless-live_storage
+		if [[ $? = 0 ]]; then
+			echo /dev/mapper/endless-live_storage
+			return 0
+		fi
+	fi
 
 	# Check for ISO layout - root partition is partition 1, storage partition
 	# exists at partition 3.


### PR DESCRIPTION
Let endless use a large file created by the installer on the exfat partition for persistent storage.