### PR TITLE
eos-live-boot-overlayfs-setup: Fix eos-map-image-file invocation

### DIFF
--- a/eos-live-boot-overlayfs-setup
+++ b/eos-live-boot-overlayfs-setup
@@ -21,7 +21,7 @@ find_storage_partition() {
 	dumpexfat -f /endless/persistent.img ${root_partition} &> /dev/null
 	if [[ $? = 0 ]]; then
 		udevadm settle
-		/usr/libexec/eos-map-image-file ${root_partition} /endless/persistent.img endless-live_storage
+		/usr/lib/eos-boot-helper/eos-map-image-file ${root_partition} /endless/persistent.img endless-live_storage
 		if [[ $? = 0 ]]; then
 			echo /dev/mapper/endless-live_storage
 			return 0


### PR DESCRIPTION
I made the false assumption that dist_libexec_SCRIPTS installed
into /usr/libexec, but I didn't create packages to adequately
confirm installation location.  The actual location on an eos
system is /usr/lib/eos-boot-helper

Fix the script to look in the right place.

https://phabricator.endlessm.com/T14891