### PR TITLE
Filter "sector-size" to sfdisk

### DIFF
--- a/dracut/repartition/endless-repartition.sh
+++ b/dracut/repartition/endless-repartition.sh
@@ -195,6 +195,9 @@ if [ -n "$preserve_partition" ]; then
 $preserve_partition"
 fi
 
+# sfdisk does not seem to like to redefinition of sector-size
+parts=$(echo "$parts" | sed -e '/^sector-size:/d')
+
 echo "$parts"
 echo "$parts" | sfdisk --force --no-reread $root_disk
 ret=$?


### PR DESCRIPTION
Some version (v2.35) of sfdisk outputs header "sector-size" but does
not accept it back. So repartition fails if not filtered.

We encountered that in GNOME OS which is using the repartition script from this repository.