### PR TITLE
dracut: Add the device mapper module to our config

### DIFF
--- a/dracut/image-boot/module-setup.sh
+++ b/dracut/image-boot/module-setup.sh
@@ -6,13 +6,13 @@ check() {
 }
 
 depends() {
-  echo systemd
+  echo systemd dm
 }
 
 install() {
   dracut_install blockdev kpartx dmsetup dumpexfat ntfsextents lsblk losetup
   instmods overlay
-  inst_rules 55-dm.rules 60-cdrom_id.rules 95-dm-notify.rules
+  inst_rules 60-cdrom_id.rules
   inst_script "$moddir"/eos-image-boot-setup /bin/eos-image-boot-setup
   inst_script "$moddir"/eos-live-storage-setup /bin/eos-live-storage-setup
   inst_script "$moddir"/eos-map-image-file /bin/eos-map-image-file


### PR DESCRIPTION
We use the device mapper in our dual boot configurations to map the file
on the user's windows partition as a block device that hosts endless.

Recently something broke in these configurations, and now systemd tries
to unmount our /var partition at boot. It appears that this may have
been a problem waiting to manifest for some time, because under 3.7.8
we see evidence of systemd wanting to unmount /var but bailing on the
process due to other conflicts.

The problem is that on the transition from initrd to real root we
have to clean the udev db to remove anything that was created with
the initrd's set of udev rules - which may differ from the booted
system's udev rules.

Once the db is cleared, udevadm trigger is used to introduce all
the devices to the booted system's ruleset.

However, device mapper entries have a DM_UDEV_PRIMARY_SOURCE flag to
indicate that they're not synthetic, and this flag is lost when the
udev db is recreated from a trigger. At this point the now seen as
synthetic events trigger some other udev rules which eventually
lead to SYSTEMD_READY=0 being added for the device.

That in turn causes systemd to see the device as not ready, which
moves it from (mounted | seen_by_udev) to (mounted). It interprets
this transition as the device having gone away, so unmounts any
filesystems it knows are on it.

Somehow that I can't remember or didn't figure out this doesn't
unmount our root partition, but it gets our /var mount which is
mounted by a generator provided by ostree.

In order to prevent this from happening we need to add the db_persist
option to all the device mapper block devices in udev. This causes
the udevadm info --cleanup-db call during startup to leave all the
device mapper block devices as they are. However, that rule should only
be present during initrd, so doing another udevadm info --cleanup-db
as root after boot can appropriately mess up the running system.

Instead of making these rules ourselves, we can pull the in with the
dracut "dm" module which, among other things, adds the appropriate
db_persist option for device mapper devices.

https://phabricator.endlessm.com/T30165