### PR TITLE
Fix installer when run from winstaller "combo" sticks

### DIFF
--- a/eos-image-boot-dm-setup
+++ b/eos-image-boot-dm-setup
@@ -48,7 +48,15 @@ fi
 
 case "${fstype}" in
 exfat)
+  # our windows installer USB sticks are exfat, and in that case there might
+  # also be a persistent.img file to make a hole around so our installer can
+  # mount the device mapper device and access the boot zip files.
+  # Letting dumpexfat fail is the easiest way to see if the file exists.
   extents=$(dumpexfat -f "${image_path}" "${host_device}")
+  persist_extents=$(dumpexfat -f "/endless/persistent.img" "${host_device}" 2>/dev/null)
+  if [ $? == 0 ]; then
+    extents="$extents"$'\n'"$persist_extents"
+  fi
   ;;
 ntfs)
   extents=$(ntfsextents "${host_device}" "${image_path}")

--- a/eos-image-boot-dm-setup.service
+++ b/eos-image-boot-dm-setup.service
@@ -4,6 +4,7 @@ DefaultDependencies=no
 After=ostree-remount.service
 Before=local-fs.target
 ConditionKernelCommandLine=endless.image.device
+ConditionPathExists=!/dev/mapper/endless-image-device
 
 [Service]
 Type=oneshot

--- a/eos-image-boot-dm-setup.service
+++ b/eos-image-boot-dm-setup.service
@@ -4,7 +4,6 @@ DefaultDependencies=no
 After=ostree-remount.service
 Before=local-fs.target
 ConditionKernelCommandLine=endless.image.device
-ConditionKernelCommandLine=!endless.live_boot
 
 [Service]
 Type=oneshot


### PR DESCRIPTION
Combo install sticks made by our windows install tool lost the ability to install endless recently
due to mistakes in the new persistent storage code.

Fix those mistakes and restore the install functionality.

https://phabricator.endlessm.com/T30318