### PR TITLE
firefox: Update MIME type associations

### DIFF
--- a/eos-migrate-firefox-profile
+++ b/eos-migrate-firefox-profile
@@ -39,6 +39,61 @@ PROFILES_INI = os.path.join(HOME_DOT_MOZILLA, "firefox", "profiles.ini")
 ENDLESS_FLATPAK_INSTALL_GROUP = "InstallFF6C2EBF42BF07E5"
 MOZILLA_FLATPAK_INSTALL_GROUP = "InstallCF146F38BCAB2D21"
 
+MIMEAPPS_LIST = os.path.join(GLib.get_user_config_dir(), "mimeapps.list")
+MIMEAPPS_GROUPS = [
+    "Default Applications",
+    "Added Associations",
+    "Removed Associations",
+]
+OLD_DESKTOP_FILE = "org.mozilla.Firefox.desktop"
+NEW_DESKTOP_FILE = "org.mozilla.firefox.desktop"
+
+
+def update_mimeapps_list(path):
+    """Update file associations, which in particular includes x-scheme-handler/http and
+    friends to specify the default web browser.
+
+    Strictly speaking, a user may have had the old Firefox specified as their default
+    browser without ever having launched it (in which case this script would not be
+    run); in practice, this seems vanishingly unlikely.
+
+    We cannot use GLib's own API to query what mime types the old Firefox desktop file
+    is a handler for, because we can't construct a GDesktopAppInfo for it, because its
+    desktop file no longer exists.
+    """
+
+    keyfile = GLib.KeyFile()
+    try:
+        keyfile.load_from_file(
+            path, GLib.KeyFileFlags.KEEP_COMMENTS | GLib.KeyFileFlags.KEEP_TRANSLATIONS,
+        )
+    except GLib.GError as gerror:
+        if gerror.matches(GLib.file_error_quark(), GLib.FileError.NOENT):
+            return
+
+        raise
+
+    changed = False
+
+    for group in MIMEAPPS_GROUPS:
+        if not keyfile.has_group(group):
+            continue
+
+        keys, _length = keyfile.get_keys(group)
+        for key in keys:
+            values = keyfile.get_string_list(group, key)
+            try:
+                i = values.index(OLD_DESKTOP_FILE)
+            except ValueError:
+                pass
+            else:
+                values[i] = NEW_DESKTOP_FILE
+                keyfile.set_string_list(group, key, values)
+                changed = True
+
+    if changed:
+        keyfile.save_to_file(path)
+
 
 def copy_install_section(path):
     """The default profile is keyed by a hash of the Firefox executable's installed
@@ -68,6 +123,7 @@ def main():
         and not os.path.isdir(APP_DATA_DIR_DOT_MOZILLA)
         and os.path.isdir(HOME_DOT_MOZILLA)
     ):
+        update_mimeapps_list(MIMEAPPS_LIST)
         copy_install_section(PROFILES_INI)
         os.rename(HOME_DOT_MOZILLA, APP_DATA_DIR_DOT_MOZILLA)
 

--- a/tests/test_migrate_firefox_profile.py
+++ b/tests/test_migrate_firefox_profile.py
@@ -12,6 +12,83 @@ from .util import BaseTestCase, system_script, import_script_as_module
 emfp = import_script_as_module("emfp", system_script("eos-migrate-firefox-profile"))
 
 
+class TestUpdateMimeappsList(BaseTestCase):
+    def setUp(self):
+        super().setUp()
+
+        self.tmp = tempfile.TemporaryDirectory()
+
+    def tearDown(self):
+        self.tmp.cleanup()
+
+    def test_nonexistent(self):
+        emfp.update_mimeapps_list(os.path.join(self.tmp.name, "mimeapps.list"))
+
+    def test_not_there(self):
+        orig_data = textwrap.dedent(
+            """
+            [Default Applications]
+            image/jpeg=eog.desktop
+            """
+        ).lstrip()
+        expected_data = orig_data
+
+        self._test(orig_data, expected_data)
+
+    def test_there(self):
+        orig_data = textwrap.dedent(
+            """
+            [Default Applications]
+            text/html=org.mozilla.Firefox.desktop
+            image/jpeg=eog.desktop
+
+            [Added Associations]
+            text/xml=google-chrome.desktop;org.mozilla.Firefox.desktop;chromium-browser.desktop;
+            """
+        ).lstrip()
+        """
+        The trailing semicolon in the [Default Applications] text/html entry is legal.
+
+        https://specifications.freedesktop.org/mime-apps-spec/latest/ar01s03.html says:
+
+            The value is a semicolon-separated list of desktop file IDs (as defined in
+            the desktop entry spec).
+
+        https://specifications.freedesktop.org/desktop-entry-spec/latest/ar01s04.html
+        says:
+
+            The multiple values should be separated by a semicolon and the value of the
+            key may be optionally terminated by a semicolon.
+
+        GKeyFile always adds the semicolon. What's fun is that when GLib itself updates
+        [Default Applications], it uses set_string() rather than set_string_list(), even
+        though it parses these as lists.
+        """
+        expected_data = textwrap.dedent(
+            """
+            [Default Applications]
+            text/html=org.mozilla.firefox.desktop;
+            image/jpeg=eog.desktop
+
+            [Added Associations]
+            text/xml=google-chrome.desktop;org.mozilla.firefox.desktop;chromium-browser.desktop;
+            """
+        ).lstrip()
+
+        self._test(orig_data, expected_data)
+
+    def _test(self, orig_data, expected_data):
+        mimeapps_list = os.path.join(self.tmp.name, "mimeapps.list")
+        with open(mimeapps_list, "w") as f:
+            f.write(orig_data)
+
+        emfp.update_mimeapps_list(mimeapps_list)
+        with open(mimeapps_list, "r") as f:
+            new_data = f.read()
+
+        self.assertEqual(expected_data, new_data)
+
+
 class TestMangleMetadataAndDesktopFile(BaseTestCase):
     def setUp(self):
         super().setUp()


### PR DESCRIPTION
Strictly speaking we should have done this for all the other
applications that we have migrated. However, the browser is more
noticeable, since there is always at least one other, higher-priority
browser installed.

https://phabricator.endlessm.com/T29746