### PR TITLE
live: Make kolibri data from eoslive available in EOS

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -24,7 +24,9 @@ dist_systemdunit_DATA = \
 	eos-live-boot-overlayfs-setup.service \
 	eos-reclaim-swap.service \
 	eos-update-flatpak-repos.service \
+	eoslive-kolibrihome-setup.service \
 	hack-remove-global-override.service \
+	run-kolibrihome.mount \
 	run-media-eoslive.mount \
 	$(NULL)
 
@@ -103,4 +105,5 @@ tmpfilesdir = $(prefix)/lib/tmpfiles.d
 dist_tmpfiles_DATA = \
 	tmpfiles.d/avahi-service-writers.conf \
 	tmpfiles.d/eos-boot-helper.conf \
+	tmpfiles.d/flatpak-overrides.conf \
 	$(NULL)

--- a/Makefile.am
+++ b/Makefile.am
@@ -25,6 +25,7 @@ dist_systemdunit_DATA = \
 	eos-reclaim-swap.service \
 	eos-update-flatpak-repos.service \
 	hack-remove-global-override.service \
+	run-media-eoslive.mount \
 	$(NULL)
 
 dist_systemduserunit_DATA = \

--- a/Makefile.am
+++ b/Makefile.am
@@ -26,6 +26,7 @@ dist_systemdunit_DATA = \
 	eos-update-flatpak-repos.service \
 	eoslive-kolibrihome-setup.service \
 	hack-remove-global-override.service \
+	run-kiwixhome.mount \
 	run-kolibrihome.mount \
 	run-media-eoslive.mount \
 	$(NULL)
@@ -105,5 +106,6 @@ tmpfilesdir = $(prefix)/lib/tmpfiles.d
 dist_tmpfiles_DATA = \
 	tmpfiles.d/avahi-service-writers.conf \
 	tmpfiles.d/eos-boot-helper.conf \
+	tmpfiles.d/flatpak-extension-kiwix-usb-content.conf \
 	tmpfiles.d/flatpak-overrides.conf \
 	$(NULL)

--- a/eoslive-kolibrihome-setup.service
+++ b/eoslive-kolibrihome-setup.service
@@ -1,0 +1,13 @@
+[Unit]
+Description=Setup Kolibri to use data from Endless Live USB Storage
+After=systemd-tmpfiles-setup.service
+ConditionKernelCommandLine=endless.image.device
+ConditionKernelCommandLine=endless.live_boot
+ConditionDirectoryNotEmpty=/run/kolibrihome
+
+[Service]
+Type=oneshot
+ExecStart=/bin/bash -c 'echo -e "[Environment]\nKOLIBRI_HOME=/run/kolibrihome" > /run/flatpak/overrides/org.learningequality.Kolibri'
+
+[Install]
+WantedBy=multi-user.target

--- a/run-kiwixhome.mount
+++ b/run-kiwixhome.mount
@@ -1,0 +1,13 @@
+[Unit]
+Description=Kiwix data from Endless Live USB Storage
+ConditionKernelCommandLine=endless.image.device
+ConditionKernelCommandLine=endless.live_boot
+ConditionDirectoryNotEmpty=/run/media/eoslive/.kiwix
+
+[Mount]
+What=/run/media/eoslive/.kiwix
+Where=/run/kiwixhome
+Options=bind
+
+[Install]
+WantedBy=multi-user.target

--- a/run-kolibrihome.mount
+++ b/run-kolibrihome.mount
@@ -1,0 +1,13 @@
+[Unit]
+Description=Kolibri data from Endless Live USB Storage
+ConditionKernelCommandLine=endless.image.device
+ConditionKernelCommandLine=endless.live_boot
+ConditionDirectoryNotEmpty=/run/media/eoslive/.kolibri
+
+[Mount]
+What=/run/media/eoslive/.kolibri
+Where=/run/kolibrihome
+Options=bind
+
+[Install]
+WantedBy=multi-user.target

--- a/run-media-eoslive.mount
+++ b/run-media-eoslive.mount
@@ -1,0 +1,11 @@
+[Unit]
+Description=Endless Live USB Storage
+ConditionKernelCommandLine=endless.image.device
+ConditionKernelCommandLine=endless.live_boot
+
+[Mount]
+What=/dev/mapper/endless-image-device
+Where=/run/media/eoslive
+
+[Install]
+WantedBy=local-fs.target

--- a/tmpfiles.d/flatpak-extension-kiwix-usb-content.conf
+++ b/tmpfiles.d/flatpak-extension-kiwix-usb-content.conf
@@ -1,0 +1,3 @@
+D /run/flatpak/extension/com.endlessm.encyclopedia.en.Content/x64_64 0755 - - -
+L /run/flatpak/extension/com.endlessm.encyclopedia.en.Content/x64_64/eos3 - - - - /run/kiwixhome/flatpak
+L /var/lib/flatpak/extension - - - - /run/flatpak/extension

--- a/tmpfiles.d/flatpak-overrides.conf
+++ b/tmpfiles.d/flatpak-overrides.conf
@@ -1,0 +1,2 @@
+D /run/flatpak/overrides 0755 - - -
+L /var/lib/flatpak/overrides - - - - /run/flatpak/overrides


### PR DESCRIPTION
Ship a mount unit to always mount /dev/mapper/endless-image-device on live USB systems. This is a device-mapper device which maps the 'eoslive' partition minus the image file that the system boots from.

If there is Kolibri content available in it, make it available for the Kolibri app in EOS.

This also incidentally fixes a bug on live+installer combo USBs when launching the installer from the FBE, backing off, then trying to launch it from the user session.

https://phabricator.endlessm.com/T22735
https://phabricator.endlessm.com/T30599
