### PR TITLE
dracut: Extract deployment ID during first boot

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -82,6 +82,7 @@ AC_CONFIG_FILES([
 	dracut/Makefile
 	dracut/image-boot/Makefile
 	dracut/repartition/Makefile
+	dracut/deployment-id/Makefile
 	dracut/customization/Makefile
 	factory-reset/Makefile
 	fallback-fb-setup/Makefile

--- a/dracut/Makefile.am
+++ b/dracut/Makefile.am
@@ -1,4 +1,4 @@
-SUBDIRS = repartition image-boot customization
+SUBDIRS = repartition deployment-id image-boot customization
 
 dracutconfdir = $(sysconfdir)/dracut.conf.d
 dist_dracutconf_DATA = endless.conf

--- a/dracut/deployment-id/Makefile.am
+++ b/dracut/deployment-id/Makefile.am
@@ -1,0 +1,4 @@
+dracutmoddir = $(prefix)/lib/dracut/modules.d/50eos-deployment-id
+dist_dracutmod_SCRIPTS = module-setup.sh \
+			 eos-metrics-deployment-id-setup
+dist_dracutmod_DATA = eos-metrics-deployment-id-setup.service

--- a/dracut/deployment-id/eos-metrics-deployment-id-setup
+++ b/dracut/deployment-id/eos-metrics-deployment-id-setup
@@ -1,0 +1,29 @@
+#!/bin/sh
+# Copyright (C) 2020 Endless OS Foundation LLC
+# Licensed under the GPLv2
+#
+# If a deployment id is found in /run/eos-metrics/deployment-id.txt, this
+# script updates the eos-image-version xattr in /sysroot, appending the
+# deployment ID to the image version.
+
+file_path="/run/eos-metrics/deployment-id.txt"
+deployment_id="$(cat $file_path)"
+if [ -z "$deployment_id" ] ; then
+  echo "Failed to read $file_path"
+  exit 1
+fi
+
+eos_image_version="$(attr -q -g eos-image-version /sysroot)"
+if [ -z "$eos_image_version" ] ; then
+  echo "Failed to read \"eos-image-version\" attribute from /sysroot"
+  exit 1
+fi
+
+new_eos_image_version="${eos_image_version}_${deployment_id}"
+echo "Updating \"eos-image-version\" to \"$new_eos_image_version\""
+attr -s eos-image-version -V "$new_eos_image_version" /sysroot
+attr_exit_status=$?
+if [ $attr_exit_status -ne 0 ] ; then
+  echo "Failed to update \"eos-image-version\""
+  exit $attr_exit_status
+fi

--- a/dracut/deployment-id/eos-metrics-deployment-id-setup.service
+++ b/dracut/deployment-id/eos-metrics-deployment-id-setup.service
@@ -1,0 +1,14 @@
+[Unit]
+Description=Set Metrics Deployment ID
+DefaultDependencies=no
+ConditionPathExists=/etc/initrd-release
+ConditionPathExists=/run/eos-metrics/deployment-id.txt
+After=sysroot.mount
+Requires=sysroot.mount
+
+[Service]
+Type=oneshot
+ExecStart=/bin/eos-metrics-deployment-id-setup
+StandardInput=null
+StandardOutput=syslog
+StandardError=syslog+console

--- a/dracut/deployment-id/module-setup.sh
+++ b/dracut/deployment-id/module-setup.sh
@@ -1,0 +1,21 @@
+# Copyright (C) 2020 Endless OS Foundation LLC
+# Licensed under the GPLv2
+
+check() {
+  return 0
+}
+
+depends() {
+  echo systemd
+}
+
+install() {
+  dracut_install attr
+  inst_script "$moddir/eos-metrics-deployment-id-setup" \
+    /bin/eos-metrics-deployment-id-setup
+  inst_simple "$moddir/eos-metrics-deployment-id-setup.service" \
+    "$systemdsystemunitdir/eos-metrics-deployment-id-setup.service"
+  mkdir -p "${initdir}/$systemdsystemunitdir/initrd.target.wants"
+  ln_r "$systemdsystemunitdir/eos-metrics-deployment-id-setup.service" \
+    "$systemdsystemunitdir/initrd.target.wants/eos-metrics-deployment-id-setup.service"
+}

--- a/dracut/endless.conf
+++ b/dracut/endless.conf
@@ -1,4 +1,4 @@
-dracutmodules="dracut-systemd systemd-initrd dash drm eos-repartition eos-image-boot plymouth kernel-modules resume ostree systemd base fs-lib eos-customization"
+dracutmodules="dracut-systemd systemd-initrd dash drm eos-repartition eos-deployment-id eos-image-boot plymouth kernel-modules resume ostree systemd base fs-lib eos-customization"
 fscks="fsck fsck.ext4"
 filesystems="isofs"
 

--- a/dracut/repartition/endless-repartition.sh
+++ b/dracut/repartition/endless-repartition.sh
@@ -34,6 +34,9 @@
 #
 # Based on code from dracut-modules-olpc.
 
+# GPT length in sectors
+GPT_LEN=33
+
 if [ $# -ge 1 ]; then
   # For testing
   orig_root_part="$1"
@@ -176,7 +179,7 @@ else
 
   # Subtract the size of the secondary GPT header at the end of the disk. We do
   # this also for MBR in case we want to convert MBR->GPT later
-  new_size=$(( new_size - 33 ))
+  new_size=$(( new_size - GPT_LEN ))
 fi
 
 # remove the last-lba line so that we fill the disk

--- a/dracut/repartition/endless-repartition.sh
+++ b/dracut/repartition/endless-repartition.sh
@@ -168,6 +168,15 @@ part_start=$(echo "$parts" | sed -n -e '$ s/.*start=[ ]\+\([0-9]\+\).*$/\1/p')
 part_end=$(( part_start + part_size ))
 echo "Dsize $disk_size PreserveStart $preserve_start Psize $part_size Pstart $part_start Pend $part_end"
 
+# Look for metrics Deployment ID data
+eos_data=$(dd if=$root_disk bs=512 count=1 skip=$(( part_end + GPT_LEN )) status=none)
+deployment_id=$(echo "$eos_data" | sed -n -e 's/.*EOS_DEPLOYMENT_ID=\(.*\);.*/\1/p')
+if [ -n "$deployment_id" ] ; then
+  echo "Found deployment ID \"$deployment_id\""
+  mkdir -p /run/eos-metrics
+  echo "$deployment_id" > /run/eos-metrics/deployment-id.txt
+fi
+
 # Calculate the new root partition size, assuming that it will expand to fill
 # all available space
 if [ -n "$preserve_start" ]; then

--- a/dracut/repartition/module-setup.sh
+++ b/dracut/repartition/module-setup.sh
@@ -17,6 +17,7 @@ install() {
   dracut_install sed
   dracut_install tune2fs
   dracut_install iconv
+  dracut_install dd
   dracut_install -o amlogic-fix-spl-checksum
   inst_script "$moddir/endless-repartition.sh" /bin/endless-repartition
   inst_simple "$moddir/endless-repartition.service" \


### PR DESCRIPTION
If deployment ID data is set in the first sector after the GPT, before the repartitioning process during first boot, extract this information and save it for metrics consumption by appending it to the eos-image-version extended file attribute on /sysroot.

https://phabricator.endlessm.com/T30721