### PR TITLE
eos-live-boot-generator: Rename .kolibri to KOLIBRI_DATA

### DIFF
--- a/eos-live-boot-generator
+++ b/eos-live-boot-generator
@@ -51,11 +51,11 @@ Description=Setup Kolibri to use data from Endless Live USB Storage
 Requires=run-media-eoslive.mount
 After=run-media-eoslive.mount systemd-tmpfiles-setup.service
 ConditionKernelCommandLine=endless.image.device
-ConditionDirectoryNotEmpty=/run/media/eoslive/.kolibri
+ConditionDirectoryNotEmpty=/run/media/eoslive/KOLIBRI_DATA
 
 [Service]
 Type=oneshot
-ExecStart=/bin/bash -c 'echo -e "[Context]\nfilesystems=/run/media/eoslive/.kolibri;\n\n[Environment]\nKOLIBRI_HOME=/run/media/eoslive/.kolibri" > /run/flatpak/overrides/org.learningequality.Kolibri'
+ExecStart=/bin/bash -c 'echo -e "[Context]\nfilesystems=/run/media/eoslive/KOLIBRI_DATA;\n\n[Environment]\nKOLIBRI_HOME=/run/media/eoslive/KOLIBRI_DATA" > /run/flatpak/overrides/org.learningequality.Kolibri'
 SETUP_KOLIBRIHOME
 ln -sf "$unit_path" "$multi_user_target_wants/"
 


### PR DESCRIPTION
https://phabricator.endlessm.com/T30828