### PR TITLE
image-boot-setup: Workaround busybox issue by manually specifying fs

### DIFF
--- a/dracut/image-boot/eos-image-boot-setup
+++ b/dracut/image-boot/eos-image-boot-setup
@@ -101,7 +101,13 @@ exfat | ntfs)
 iso9660)
   # Mount the ISO image
   mkdir /cd
-  if ! mount ${host_device} /cd; then
+  # /usr/bin/mount recently became busybox, and it seems to have a hard time
+  # guessing the filesystem when the isofs kernel module isn't loaded.
+  # If we specify it manually, it should be ok.
+  #
+  # Even with util-linux mount, manually specifying this saves a few
+  # pointless read operations, so it's probably a good idea anyway.
+  if ! mount -t iso9660 ${host_device} /cd; then
     echo "Failed to mount ${host_device}"
     exit 1
   fi


### PR DESCRIPTION
We recently started using the dracut busybox module, and this has
replaced util-linux mount with busybox's implementation of mount.

For some reason busybox isn't figuring out what fs type our .iso
files are when the isofs kernel module isn't already loaded.

Specify it manually when mounting to work around this problem.

https://phabricator.endlessm.com/T30937