### PR TITLE
eos-image-boot-setup: Fix calls to busybox's losetup

### DIFF
--- a/dracut/image-boot/eos-image-boot-setup
+++ b/dracut/image-boot/eos-image-boot-setup
@@ -113,7 +113,8 @@ iso9660)
   fi
 
   # Create a loopback device backing the squashfs
-  if ! image_device=$(losetup --find --show /cd/${image_path}); then
+  image_device=$(losetup -f)
+  if ! image_device=$(losetup ${image_device} /cd/${image_path}); then
     echo "losetup failed for /cd/${image_path}"
     exit 1
   fi
@@ -138,9 +139,10 @@ if [ -n "$squash_device" ]; then
     echo "Failed to mount ${squash_device}"
     exit 1
   fi
-  
+
   # Create a loopback device backing the endless image
-  host_device=$(losetup --find --show /squash/endless.img)
+  host_device=$(losetup -f)
+  losetup ${host_device} /squash/endless.img
   linear_map "$host_device"
 fi
 


### PR DESCRIPTION
Busybox losetup does not have --show. Its -f will show the next
available loop device, or, if you pass an image file, it will use (but
not show) the next available loop device.

https://phabricator.endlessm.com/T30937