### PR TITLE
dracut: Add protective spaces for shell variable concatenation

### DIFF
--- a/dracut/endless.conf
+++ b/dracut/endless.conf
@@ -12,4 +12,4 @@ omit_drivers="nouveau"
 
 # Ship the bfq IO scheduler module in the initrd, as it's relied upon by
 # our udev rules that detect block devices
-add_drivers+="bfq"
+add_drivers+=" bfq "


### PR DESCRIPTION
Dracut parses config files by executing them in the shell, so config
lines that add to variables are required to have spaces inside the
strings they add, or options can get crushed together.

Our config has always been "wrong", but didn't generate a warning until
we upgraded to a more recent version of dracut. It also doesn't fail
because we only have the one instance of add_drivers+=

Fix the warning by adding protective spaces to the string.

https://phabricator.endlessm.com/T31021