### PR TITLE
model-s2idle: Make Pinebook Pro suspend to idle

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -23,6 +23,7 @@ dist_systemdunit_DATA = \
 	eos-firstboot.service \
 	eos-image-boot-dm-setup.service \
 	eos-live-boot-overlayfs-setup.service \
+	eos-model-s2idle.service \
 	eos-reclaim-swap.service \
 	eos-update-flatpak-repos.service \
 	hack-remove-global-override.service \

--- a/eos-model-s2idle.service
+++ b/eos-model-s2idle.service
@@ -1,0 +1,9 @@
+[Unit]
+Description=Make system sleep with s2idle
+ConditionArchitecture=arm64
+
+[Service]
+ExecStart=/usr/bin/sh -c 'grep -q "Pine64 Pinebook Pro" /sys/firmware/devicetree/base/model && echo s2idle > /sys/power/mem_sleep'
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
According to Pine64 forum [1], Pinebook Pro can only s2idle, instead of
S3 with mainline U-Boot now. This patch provides a systemd service unit,
which checks the model is Pinebook Pro and sets it use s2idle.

[1]: https://forum.pine64.org/showthread.php?tid=9974

https://phabricator.endlessm.com/T31049