### PR TITLE
Migrate Chromium to Flathub

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -109,6 +109,7 @@ dist_libexec_SCRIPTS = \
 tmpfilesdir = $(prefix)/lib/tmpfiles.d
 dist_tmpfiles_DATA = \
 	tmpfiles.d/avahi-service-writers.conf \
+	tmpfiles.d/chromium-system-services.conf \
 	tmpfiles.d/eos-boot-helper.conf \
 	tmpfiles.d/flatpak-overrides.conf \
 	$(NULL)

--- a/Makefile.am
+++ b/Makefile.am
@@ -29,6 +29,7 @@ dist_systemdunit_DATA = \
 	$(NULL)
 
 dist_systemduserunit_DATA = \
+	eos-migrate-chromium-profile.service \
 	eos-migrate-firefox-profile.service \
 	$(NULL)
 
@@ -67,6 +68,7 @@ install-data-hook:
 	$(INSTALL_DATA) $(srcdir)/var-endless_x2dextra.mount \
 	  '$(DESTDIR)$(systemdunitdir)/var-endless\x2dextra.mount'
 	$(MKDIR_P) '$(DESTDIR)$(systemduserunitdir)/gnome-session.target.wants'
+	ln -s ../eos-migrate-chromium-profile.service '$(DESTDIR)$(systemduserunitdir)/gnome-session.target.wants'
 	ln -s ../eos-migrate-firefox-profile.service '$(DESTDIR)$(systemduserunitdir)/gnome-session.target.wants'
 
 uninstall-hook:
@@ -100,6 +102,7 @@ dist_sbin_SCRIPTS = \
 
 dist_libexec_SCRIPTS = \
 	dracut/image-boot/eos-map-image-file \
+	eos-migrate-chromium-profile \
 	eos-migrate-firefox-profile \
 	$(NULL)
 

--- a/configure.ac
+++ b/configure.ac
@@ -5,6 +5,7 @@ AC_CONFIG_SRCDIR([eos-firstboot])
 PKG_PROG_PKG_CONFIG
 
 AC_PROG_CC
+AC_CANONICAL_TARGET
 
 dnl Get systemd unit and udev rules directories. Add options so that they
 dnl can be set under $prefix for distcheck.
@@ -87,6 +88,17 @@ AC_ARG_WITH([dbussystemconfigdir],
             [dbussystemconfigdir="$withval"], [dbussystemconfigdir="/usr/share/dbus-1/system.d"])
 AC_SUBST(dbussystemconfigdir)
 
+FLATPAK_ARCH="x86_64"
+case $target_cpu in
+  arm*)
+    FLATPAK_ARCH="arm"
+  ;;
+  aarch64*)
+    FLATPAK_ARCH="aarch64"
+  ;;
+esac
+AC_SUBST(FLATPAK_ARCH)
+
 AC_CONFIG_FILES([
 	Makefile
 	dracut/Makefile
@@ -100,5 +112,6 @@ AC_CONFIG_FILES([
 	psi-monitor/Makefile
 	record-boot-success/Makefile
 	tests/Makefile
+	tmpfiles.d/chromium-system-services.conf
 ])
 AC_OUTPUT

--- a/eos-migrate-chromium-profile
+++ b/eos-migrate-chromium-profile
@@ -1,0 +1,150 @@
+#!/usr/bin/python3
+#
+# eos-migrate-chromium-profile: move users' Chromium profile to its new home
+#
+# This script is based on eos-migrate-firefox-profile.
+#
+# Copyright © 2020 Endless OS Foundation LLC
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+
+import fileinput
+import os
+from gi.repository import GLib
+
+USER_HOME_DIR = os.path.expanduser("~/")
+DESKTOP_SHORTCUTS_DIR = os.path.join(USER_HOME_DIR, ".local", "share", "applications")
+OLD_CHROMIUM_CONFIG_DIR = os.path.join(USER_HOME_DIR, ".config", "chromium")
+NEW_CHROMIUM_DATA_DIR = os.path.join(USER_HOME_DIR, ".var", "app",
+                                     "org.chromium.Chromium")
+NEW_CHROMIUM_CONFIG_DIR = os.path.join(NEW_CHROMIUM_DATA_DIR, "config", "chromium")
+
+OLD_WIDEVINE_SYSTEM_DIR = os.path.join(os.path.sep, "usr", "lib",
+                                       "chromium-browser", "WidevineCdm")
+
+MIMEAPPS_LIST = os.path.join(GLib.get_user_config_dir(), "mimeapps.list")
+MIMEAPPS_GROUPS = [
+    "Default Applications",
+    "Added Associations",
+    "Removed Associations",
+]
+OLD_DESKTOP_FILE = "chromium-browser.desktop"
+NEW_DESKTOP_FILE = "org.chromium.Chromium.desktop"
+
+
+def update_mimeapps_list(path):
+    """Update file associations, which in particular includes x-scheme-handler/http and
+    friends to specify the default web browser.
+
+    We cannot use GLib's own API to query what mime types the old Chromium desktop file
+    is a handler for, because we can't construct a GDesktopAppInfo for it, because its
+    desktop file no longer exists.
+    """
+
+    keyfile = GLib.KeyFile()
+    try:
+        keyfile.load_from_file(
+            path, GLib.KeyFileFlags.KEEP_COMMENTS | GLib.KeyFileFlags.KEEP_TRANSLATIONS,
+        )
+    except GLib.GError as gerror:
+        if gerror.matches(GLib.file_error_quark(), GLib.FileError.NOENT):
+            return
+
+        raise
+
+    changed = False
+
+    for group in MIMEAPPS_GROUPS:
+        if not keyfile.has_group(group):
+            continue
+
+        keys, _length = keyfile.get_keys(group)
+        for key in keys:
+            values = keyfile.get_string_list(group, key)
+            try:
+                i = values.index(OLD_DESKTOP_FILE)
+            except ValueError:
+                pass
+            else:
+                values[i] = NEW_DESKTOP_FILE
+                keyfile.set_string_list(group, key, values)
+                changed = True
+
+    if changed:
+        keyfile.save_to_file(path)
+
+
+def update_desktop_shortcut(path):
+    keyfile = GLib.KeyFile()
+    print("path: " + path)
+    keyfile.load_from_file(path, GLib.KeyFileFlags.NONE)
+
+    group = "Desktop Entry"
+    if not keyfile.has_group(group):
+        return
+
+    exec_cmd = keyfile.get_string(group, "Exec")
+    if not exec_cmd.startswith("/usr/bin/chromium-browser"):
+        return
+
+    keyfile.set_string(group, "Exec",
+                       "/usr/bin/flatpak run org.chromium.Chromium" +
+                       exec_cmd[len("/usr/bin/chromium-browser"):])
+    keyfile.set_string(group, "X-Flatpak-Part-Of", "org.chromium.Chromium")
+    keyfile.save_to_file(path)
+
+
+def update_desktop_shortcuts():
+    for filename in os.listdir(DESKTOP_SHORTCUTS_DIR):
+        if filename.endswith(".desktop"):
+            update_desktop_shortcut(os.path.join(DESKTOP_SHORTCUTS_DIR,
+                                                 filename))
+
+
+def update_old_config_references(path):
+    if not os.path.isfile(path):
+        return
+
+    for line in fileinput.input(path, inplace=True):
+        line = line.replace(OLD_CHROMIUM_CONFIG_DIR, NEW_CHROMIUM_CONFIG_DIR)
+        line = line.replace(OLD_WIDEVINE_SYSTEM_DIR, "")
+        print(line, end='')
+
+
+def main():
+    migrated_file = os.path.join(NEW_CHROMIUM_DATA_DIR, ".migrated")
+    if os.path.exists(migrated_file):
+        return
+
+    update_mimeapps_list(MIMEAPPS_LIST)
+    update_desktop_shortcuts()
+
+    if (
+        os.path.isdir(OLD_CHROMIUM_CONFIG_DIR) and
+        not os.path.isdir(NEW_CHROMIUM_CONFIG_DIR)
+    ):
+        update_old_config_references(
+            os.path.join(OLD_CHROMIUM_CONFIG_DIR,
+                         "WidevineCdm", "latest-component-updated-widevine-cdm"))
+        os.makedirs(os.path.dirname(NEW_CHROMIUM_CONFIG_DIR), exist_ok=True)
+        os.rename(OLD_CHROMIUM_CONFIG_DIR, NEW_CHROMIUM_CONFIG_DIR)
+
+    os.makedirs(NEW_CHROMIUM_DATA_DIR, exist_ok=True)
+
+    os.mknod(migrated_file)
+
+
+if __name__ == "__main__":
+    main()

--- a/eos-migrate-chromium-profile.service
+++ b/eos-migrate-chromium-profile.service
@@ -1,0 +1,13 @@
+[Unit]
+Description=Migrate Chromium profile to new path
+
+ConditionPathExists=!%h/.var/app/org.chromium.Chromium/.migrated
+
+[Service]
+Type=oneshot
+ExecStart=/usr/lib/eos-boot-helper/eos-migrate-chromium-profile
+Restart=no
+RemainAfterExit=yes
+
+[Install]
+WantedBy=gnome-session.target

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -9,6 +9,7 @@ EXTRA_DIST = \
 	test_image_boot.py \
 	test_live_boot_generator.py \
 	test_live_storage.py \
+	test_migrate_chromium_profile.py \
 	test_migrate_firefox_profile.py \
 	test_repartition.py \
 	test_repartition_mbr.py \

--- a/tests/test_migrate_chromium_profile.py
+++ b/tests/test_migrate_chromium_profile.py
@@ -1,0 +1,188 @@
+#!/usr/bin/python3
+"""
+Tests eos-migrate-chromium-profile
+
+This test is based on test_migrate_firefox_profile.py.
+"""
+
+import tempfile
+import textwrap
+import os
+
+from .util import BaseTestCase, system_script, import_script_as_module
+
+emfp = import_script_as_module("emfp", system_script("eos-migrate-chromium-profile"))
+
+
+class TestUpdateMimeappsList(BaseTestCase):
+    def setUp(self):
+        super().setUp()
+
+        self.tmp = tempfile.TemporaryDirectory()
+
+    def tearDown(self):
+        self.tmp.cleanup()
+
+    def test_nonexistent(self):
+        emfp.update_mimeapps_list(os.path.join(self.tmp.name, "mimeapps.list"))
+
+    def test_not_there(self):
+        orig_data = textwrap.dedent(
+            """
+            [Default Applications]
+            image/jpeg=eog.desktop
+            """
+        ).lstrip()
+        expected_data = orig_data
+
+        self._test(orig_data, expected_data)
+
+    def test_there(self):
+        orig_data = textwrap.dedent(
+            """
+            [Default Applications]
+            text/html=chromium-browser.desktop
+            image/jpeg=eog.desktop
+
+            [Added Associations]
+            text/xml=google-chrome.desktop;org.mozilla.firefox.desktop;chromium-browser.desktop;
+            """
+        ).lstrip()
+        """
+        The trailing semicolon in the [Default Applications] text/html entry is legal.
+
+        https://specifications.freedesktop.org/mime-apps-spec/latest/ar01s03.html says:
+
+            The value is a semicolon-separated list of desktop file IDs (as defined in
+            the desktop entry spec).
+
+        https://specifications.freedesktop.org/desktop-entry-spec/latest/ar01s04.html
+        says:
+
+            The multiple values should be separated by a semicolon and the value of the
+            key may be optionally terminated by a semicolon.
+
+        GKeyFile always adds the semicolon. What's fun is that when GLib itself updates
+        [Default Applications], it uses set_string() rather than set_string_list(), even
+        though it parses these as lists.
+        """
+        expected_data = textwrap.dedent(
+            """
+            [Default Applications]
+            text/html=org.chromium.Chromium.desktop;
+            image/jpeg=eog.desktop
+
+            [Added Associations]
+            text/xml=google-chrome.desktop;org.mozilla.firefox.desktop;org.chromium.Chromium.desktop;
+            """
+        ).lstrip()
+
+        self._test(orig_data, expected_data)
+
+    def _test(self, orig_data, expected_data):
+        mimeapps_list = os.path.join(self.tmp.name, "mimeapps.list")
+        with open(mimeapps_list, "w") as f:
+            f.write(orig_data)
+
+        emfp.update_mimeapps_list(mimeapps_list)
+        with open(mimeapps_list, "r") as f:
+            new_data = f.read()
+
+        self.assertEqual(expected_data, new_data)
+
+
+class TestUpdateDesktopShortcuts(BaseTestCase):
+    def setUp(self):
+        super().setUp()
+
+        self.tmp = tempfile.TemporaryDirectory()
+
+    def tearDown(self):
+        self.tmp.cleanup()
+
+    def test_not_there(self):
+        orig_data = textwrap.dedent(
+            """
+            [Desktop Entry]
+            Exec=/usr/bin/eos-google-chrome --profile-directory=Default
+            """
+        ).lstrip()
+        expected_data = orig_data
+
+        self._test(orig_data, expected_data)
+
+    def test_there(self):
+        orig_data = textwrap.dedent(
+            """
+            [Desktop Entry]
+            Exec=/usr/bin/chromium-browser --profile-directory=Default
+            """
+        ).lstrip()
+        expected_data = textwrap.dedent(
+            """
+            [Desktop Entry]
+            Exec=/usr/bin/flatpak run org.chromium.Chromium --profile-directory=Default
+            X-Flatpak-Part-Of=org.chromium.Chromium
+            """
+        ).lstrip()
+
+        self._test(orig_data, expected_data)
+
+    def _test(self, orig_data, expected_data):
+        test_desktop = os.path.join(self.tmp.name,
+                                    "test.desktop")
+        with open(test_desktop, "w") as f:
+            f.write(orig_data)
+
+        emfp.update_desktop_shortcut(test_desktop)
+        with open(test_desktop, "r") as f:
+            new_data = f.read()
+
+        self.assertEqual(expected_data, new_data)
+
+
+class TestUpdateOldConfigReferences(BaseTestCase):
+    def setUp(self):
+        super().setUp()
+
+        self.tmp = tempfile.TemporaryDirectory()
+
+    def tearDown(self):
+        self.tmp.cleanup()
+
+    def test_nonexistent(self):
+        emfp.update_mimeapps_list(os.path.join(self.tmp.name, "mimeapps.list"))
+
+    def test_not_there(self):
+        orig_data = ""
+        expected_data = orig_data
+
+        self._test(orig_data, expected_data)
+
+    def test_there_system(self):
+        orig_data = '{"Path":"/usr/lib/chromium-browser/WidevineCdm"}'
+        expected_data = '{"Path":""}'
+
+        self._test(orig_data, expected_data)
+
+    def test_there_local(self):
+        user_home_dir = os.path.expanduser("~/")
+        orig_data = \
+            '{"Path":"' + user_home_dir + '.config/chromium/WidevineCdm/4.10.1610.0"}'
+        expected_data = \
+            '{"Path":"' + user_home_dir + \
+            '.var/app/org.chromium.Chromium/config/chromium/WidevineCdm/4.10.1610.0"}'
+
+        self._test(orig_data, expected_data)
+
+    def _test(self, orig_data, expected_data):
+        last_updated_widevine = os.path.join(self.tmp.name,
+                                             "latest-component-updated-widevine-cdm")
+        with open(last_updated_widevine, "w") as f:
+            f.write(orig_data)
+
+        emfp.update_old_config_references(last_updated_widevine)
+        with open(last_updated_widevine, "r") as f:
+            new_data = f.read()
+
+        self.assertEqual(expected_data, new_data)

--- a/tmpfiles.d/chromium-system-services.conf.in
+++ b/tmpfiles.d/chromium-system-services.conf.in
@@ -1,0 +1,6 @@
+D /run/flatpak/extension/org.chromium.Chromium.Policy.system-policies 0755 - - -
+D /run/flatpak/extension/org.chromium.Chromium.Policy.system-policies/@FLATPAK_ARCH@ 0755 - - -
+L /run/flatpak/extension/org.chromium.Chromium.Policy.system-policies/@FLATPAK_ARCH@/1 - - - - /etc/chromium-browser
+D /run/flatpak/extension/org.chromium.Chromium.Extension.system-extensions 0755 - - -
+D /run/flatpak/extension/org.chromium.Chromium.Extension.system-extensions/@FLATPAK_ARCH@ 0755 - - -
+L /run/flatpak/extension/org.chromium.Chromium.Extension.system-extensions/@FLATPAK_ARCH@/1 - - - - /usr/share/chromium


### PR DESCRIPTION
General notes on migration:
- `$config_dir/Default/Preferences` have a few mentions to `/usr/lib/chromium-browser/resources/` which doesn't even exist in the current version. The values are not updated during migration.
- Some services credentials (e.g. gmail) are lost during migration (requiring re-login)
- Some log files have entries referring to `~/.config/chromium`. This is ignored and log files are unchanged as they may be useful in case we need to differ logs from old and new version
- The migration always runs if `~/.var/app/org.chromium.Chromium/.migrated` (created at the end of the migration) doesn't exist, even if `~/.var/app/org.chromium.Chromium` does:
  - This is such that we can update `~/.config/mimeapps.list` to point the new chromium in case the old chromium is specified as default there but the user never ran it
  - And also to update any old desktop shortcut on `~/.local/share/applications` that'd refer to the old chromium as the executable (`Exec=` starts with `/usr/bin/chromium-browser`)
  - Note that the actual user profile migration is skipped if `~/.var/app/org.chromium.Chromium` already exists or if        `~/.config/chromium` doesn't exist by the time the migration runs

https://phabricator.endlessm.com/T30997