### PR TITLE
eos-update-flatpak-repos: Fix a missing ref edge case

### DIFF
--- a/eos-update-flatpak-repos
+++ b/eos-update-flatpak-repos
@@ -1580,6 +1580,9 @@ def migrate_extra_data(old_ref, new_ref):
     new_deploy = new_ref.get_deploy_dir()
     new_extra = os.path.join(new_deploy, 'files', 'extra')
 
+    if not os.path.exists(old_extra):
+        return
+
     if os.path.exists(new_extra):
         # either the user manually installed Skype from Flathub, or we got
         # this far but died before uninstalling the old ref last time
@@ -1695,7 +1698,6 @@ def _migrate_installed_flatpaks():
 
             try:
                 vendor_prefixes = frozenset()
-                migrate_extra = is_extra_data(repo, ostree_refs[old_ostree_ref])
 
                 # copy the old ref to the new one, pointing at the same commit
                 if old_ostree_ref in ostree_refs and not new_ref:
@@ -1703,6 +1705,7 @@ def _migrate_installed_flatpaks():
                                  .format(old_ostree_ref,
                                          ostree_refs[old_ostree_ref],
                                          new_ostree_ref))
+                    migrate_extra = is_extra_data(repo, ostree_refs[old_ostree_ref])
                     repo.prepare_transaction()
                     try:
                         kwargs = {}
@@ -1740,17 +1743,22 @@ def _migrate_installed_flatpaks():
                                                     Flatpak.InstallFlags.NO_TRIGGERS,
                                                     new_origin, kind, new_name,
                                                     arch, new_branch)
+                        triggers_needed = True
                         refs.append(new_ref)
 
-                    if migrate_extra:
-                        migrate_extra_data(ref, new_ref)
+                    migrate_extra_data(ref, new_ref)
 
-                    logging.info('Uninstalling old ref: {}'.format(old_ostree_ref))
-                    inst.uninstall_full(Flatpak.UninstallFlags.NO_PRUNE |
-                                        Flatpak.UninstallFlags.NO_TRIGGERS,
-                                        kind, name, arch, branch)
+                    try:
+                        logging.info('Uninstalling old ref: {}'.format(old_ostree_ref))
+                        inst.uninstall_full(Flatpak.UninstallFlags.NO_PRUNE |
+                                            Flatpak.UninstallFlags.NO_TRIGGERS,
+                                            kind, name, arch, branch)
 
-                    triggers_needed = True
+                        triggers_needed = True
+                    except GLib.Error as err:
+                        if not err.matches(Flatpak.error_quark(),
+                                           Flatpak.Error.NOT_INSTALLED):
+                            raise
 
                     # TODO: ideally we would defer the removal of the old app
                     # until after the deploy file edits had been completed, so


### PR DESCRIPTION
A user on the forum hit this error:

```
INFO:root:Found gnome:runtime/org.gnome.Platform/x86_64/3.28 to migrate to flathub:runtime/org.gnome.Platform/x86_64/3.28
ERROR:root:Failure applying migration to org.gnome.Platform
Traceback (most recent call last):
  File "/sysroot/home/irena/eos-update-flatpak-repos", line 1698, in _migrate_installed_flatpaks
    migrate_extra = is_extra_data(repo, ostree_refs[old_ostree_ref])
KeyError: 'gnome:runtime/org.gnome.Platform/x86_64/3.28'
```

So, make the code a bit more robust so that it doesn't error out when
the old ref doesn't exist and we can still migrate the deploy file.
We had already encoded the assumption that the old ref might not exist
with the check "if old_ostree_ref in ostree_refs and not new_ref:", so
this just makes it so we don't error out in that case.

Reference:
https://community.endlessos.com/t/issues-with-updates-i-am-not-able-to-update-anything/14838

https://phabricator.endlessm.com/T31079