### PR TITLE
eos-update-flatpak-repos: Use the correct kind for app extensions

### DIFF
--- a/eos-update-flatpak-repos
+++ b/eos-update-flatpak-repos
@@ -1704,6 +1704,7 @@ def _migrate_installed_flatpaks():
 
         for ref in matching_refs:
             origin = ref.get_origin()
+            kind = ref.get_kind()
             name = ref.get_name()
             arch = ref.get_arch()
             branch = ref.get_branch()

--- a/eos-update-flatpak-repos
+++ b/eos-update-flatpak-repos
@@ -1789,8 +1789,10 @@ def _migrate_installed_flatpaks():
 
                         triggers_needed = True
                     except GLib.Error as err:
-                        if not err.matches(Flatpak.error_quark(),
-                                           Flatpak.Error.NOT_INSTALLED):
+                        if err.matches(Flatpak.error_quark(),
+                                       Flatpak.Error.NOT_INSTALLED):
+                            logging.warning("Uninstall failed", exc_info=True)
+                        else:
                             raise
 
                     # TODO: ideally we would defer the removal of the old app


### PR DESCRIPTION
Without this change, having matched `runtime/com.hack_computer.Clubhouse.Locale/x86_64/eos3`, the script would try and fail to uninstall `app/com.hack_computer.Clubhouse.Locale/x86_64/eos3`.

Unfortunately the error was masked by c262b983eaf649b91bdb0c9a25d2d3214bee4ea2.

Add a warning in the previously silently-failing case, and fix the logic error that caused the wrong thing to be uninstalled.

https://phabricator.endlessm.com/T31185
