### PR TITLE
tmpfiles: Ensure /etc/chromium-browser exists before attempting to create a symlink to it

### DIFF
--- a/tmpfiles.d/chromium-system-services.conf.in
+++ b/tmpfiles.d/chromium-system-services.conf.in
@@ -1,3 +1,4 @@
+D /etc/chromium-browser 0755 - - -
 D /run/flatpak/extension/org.chromium.Chromium.Policy.system-policies 0755 - - -
 D /run/flatpak/extension/org.chromium.Chromium.Policy.system-policies/@FLATPAK_ARCH@ 0755 - - -
 L /run/flatpak/extension/org.chromium.Chromium.Policy.system-policies/@FLATPAK_ARCH@/1 - - - - /etc/chromium-browser


### PR DESCRIPTION
This directory used to be created by the chromium-browser system package (which is no longer present) and is used when setting up the `org.chromium.Chromium.Policy.system-policies` flatpak extension. The lack of this directory breaks the extension and in turn the chromium flatpak fails to startup. Let's fix it by ensuring the dir exists when setting up the extension.

https://phabricator.endlessm.com/T30997