### PR TITLE
Revert "eos-image-boot-dm-setup: Don't start if the dm file already exists"

### DIFF
--- a/eos-image-boot-dm-setup.service
+++ b/eos-image-boot-dm-setup.service
@@ -4,7 +4,6 @@ DefaultDependencies=no
 After=ostree-remount.service
 Before=local-fs.target
 ConditionKernelCommandLine=endless.image.device
-ConditionPathExists=!/dev/mapper/endless-image-device
 
 [Service]
 Type=oneshot


### PR DESCRIPTION
This reverts commit 9589ea4ae7df358f4994ab308080060a90db46c8.

This condition is preventing eos-image-boot-dm-setup.service from
getting started on some setups with the Endless Key, in which case the
persistent storage file never gets mapped.

https://phabricator.endlessm.com/T30376