### PR TITLE
eos-update-flatpak-repos: Workaround to fix issue migrating com.hack_computer_Clubhouse.Locale

### DIFF
--- a/eos-update-flatpak-repos
+++ b/eos-update-flatpak-repos
@@ -132,6 +132,11 @@ def _remove_remotes():
 
 # dict of remote -> list of runtimes
 RUNTIMES_TO_REMOVE = {
+    "eos-apps": [
+        # remove partially-installed, empty extension (which can't currently
+        # be migrated) before migrating main app (T31185)
+        "com.hack_computer.Clubhouse.Locale",
+    ],
 }
 
 

--- a/eos-update-flatpak-repos
+++ b/eos-update-flatpak-repos
@@ -157,7 +157,7 @@ def _remove_runtimes():
         logging.info("Removing runtime {} from {}"
                      .format(refspec, inst.get_path().get_path()))
         subprocess.check_call(['flatpak', 'uninstall', '--system',
-                               '--runtime', refspec])
+                               '--runtime', '--noninteractive', refspec])
 
 
 # From 3.7.6 through 3.7.8, images were shipped with remote URLs using


### PR DESCRIPTION
This adds an workaround to fix an issue when migrating `com.hack_computer_Clubhouse.Locale` from `eos-apps` to `flathub`. The current migration fails when attempting to update the runtime when partially installed (e.g. only has a subset of the available
directories, corresponding to the locales on the system). To work around that we make sure to uninstall the old (from `eos-apps`) runtime before attempting the migration.

That has the side effect that the new `.Locale` won't get installed until the app (Clubhouse) gets updated next (either via automatic updates or manually) or if the user manually installs it.

Given the `.Locale` runtime is not mandatory the app should still work fine.

https://phabricator.endlessm.com/T31185