### PR TITLE
eos-image-boot-dm-setup: Set RemainAfterExit=yes and fix error checking logic

### DIFF
--- a/eos-image-boot-dm-setup
+++ b/eos-image-boot-dm-setup
@@ -50,15 +50,7 @@ fi
 
 case "${fstype}" in
 exfat)
-  # our windows installer USB sticks are exfat, and in that case there might
-  # also be a persistent.img file to make a hole around so our installer can
-  # mount the device mapper device and access the boot zip files.
-  # Letting dumpexfat fail is the easiest way to see if the file exists.
   extents=$(dumpexfat -f "${image_path}" "${host_device}")
-  persist_extents=$(dumpexfat -f "/endless/persistent.img" "${host_device}" 2>/dev/null)
-  if [ $? == 0 ]; then
-    extents="$extents"$'\n'"$persist_extents"
-  fi
   ;;
 ntfs)
   extents=$(ntfsextents "${host_device}" "${image_path}")
@@ -72,6 +64,17 @@ esac
 if [ $? != 0 ]; then
   echo "Failed to lookup ${image_path} on ${host_device} (${fstype})"
   exit 1
+fi
+
+if [ ${fstype} == "exfat" ] ; then
+  # exFAT USB sticks may have a persistent.img file for persistent storage, in
+  # which case we need to poke a hole where it lives as well, so our installer
+  # can mount the device mapper device and access the boot zip files.
+  # Letting dumpexfat fail is the easiest way to see if such file exists.
+  persist_extents=$(dumpexfat -f "/endless/persistent.img" "${host_device}" 2>/dev/null)
+  if [ $? == 0 ]; then
+    extents="$extents"$'\n'"$persist_extents"
+  fi
 fi
 
 # Sort the file extents so we create the holes in the correct places

--- a/eos-image-boot-dm-setup
+++ b/eos-image-boot-dm-setup
@@ -3,7 +3,9 @@
 # Licensed under the GPLv2
 #
 # When booting from an image file hosted on a filesystem, this program maps the
-# host filesystem to a dm-device with holes where the image file lives.
+# host filesystem to a dm-device with holes where the image file and
+# persistent.img files live.
+
 if [ $# -ge 1 ]; then
   # For testing
   host_device="$1"

--- a/eos-image-boot-dm-setup.service
+++ b/eos-image-boot-dm-setup.service
@@ -8,6 +8,7 @@ ConditionKernelCommandLine=endless.image.device
 [Service]
 Type=oneshot
 ExecStart=/usr/sbin/eos-image-boot-dm-setup
+RemainAfterExit=yes
 
 [Install]
 WantedBy=local-fs.target


### PR DESCRIPTION
We have seen eos-image-boot-dm-setup.service being launched twice by systemd for some reason that is not clear, but adding
RemainAfterExit=yes to the unit file prevents that from happening.

Also, the error checking logic there relies on only one thing being done in each branch of the case statement, since it looks at the return value from the last commant ($?), so this PR also moves the dumpexfat of persistent.img out of the case statement, so the error checking works as designed.

https://phabricator.endlessm.com/T30376