### PR TITLE
eos-live-boot-overlayfs-setup: Limit blkid output to one device

### DIFF
--- a/eos-live-boot-overlayfs-setup
+++ b/eos-live-boot-overlayfs-setup
@@ -12,20 +12,34 @@ mount -o remount,user_xattr /run
 find_storage_partition() {
 	local bootdev=$(grep -oP "endless\.image\.device=UUID=[^ ]+" /proc/cmdline)
 	bootdev=${bootdev:21}
-	[ -n "${bootdev}" ] || return 1
+	if [ -z "${bootdev}" ] ; then
+		echo "Failed to extract endless.image.device from kernel command line" >&2
+		return 1
+	fi
 
 	local root_partition=$(blkid --output device --match-token "${bootdev}")
-	[ -b "${root_partition}" ] || return 1
+	if [ ! -b "${root_partition}" ] ; then
+		echo "String passed on endless.image.device does not represent a block device" >&2
+		return 1
+	fi
 
-
-	dumpexfat -f /endless/persistent.img ${root_partition} &> /dev/null
+	# dumpexfat here is really only checking if the device passed in
+	# endless.image.device has an exfat file system that contains a
+	# persistent storage file at the expected path; eos-map-image-file will
+	# run dumpexfat again to find the file extents.
+	local pfpath="/endless/persistent.img"
+	dumpexfat -f ${pfpath} ${root_partition} &> /dev/null
 	if [[ $? = 0 ]]; then
+		echo "Found ${pfpath} in ${root_partition} (exfat), using it for persistent storage" >&2
 		udevadm settle
-		/usr/lib/eos-boot-helper/eos-map-image-file ${root_partition} /endless/persistent.img endless-live_storage
+		/usr/lib/eos-boot-helper/eos-map-image-file ${root_partition} ${pfpath} endless-live_storage
 		if [[ $? = 0 ]]; then
 			echo /dev/mapper/endless-live_storage
 			return 0
 		fi
+		echo "Failed to map ${pfpath} in ${root_partition} as a dm-device for persistent storage" >&2
+	else
+		echo "Could not find ${pfpath} in ${root_partition}, looking for a persistent storage partition" >&2
 	fi
 
 	# Check for ISO layout - root partition is partition 1, storage partition
@@ -47,8 +61,10 @@ setup_and_mount_storage() {
 	# Check for the marker installed at partition creation time.
 	# If found, we know we've found the right partition and it's ready
 	# for formatting.
+	echo "Looking for endless_live_storage_marker in ${device}" >&2
 	read -r -d '' -N 27 marker < ${device}
 	if [ "${marker}" = "endless_live_storage_marker" ]; then
+		echo "Marker found, formatting ${device}" >&2
 		mke2fs -t ext4 -O dir_index,^huge_file -m 1 -L endless-live \
 			"${device}"
 		# let udev become aware of new device
@@ -56,10 +72,12 @@ setup_and_mount_storage() {
 	fi
 
 	# Check the partition label
+	echo "Checking the endless-live label in ${device}" >&2
 	label=$(e2label "${device}" 2>/dev/null)
 	[ $? = 0 ] || return 1
 	[ "${label}" = "endless-live" ] || return 1
 
+	echo "endless-live label matched, mounting ${device}" >&2
 	mkdir -p /run/eos-live
 	mount "${device}" /run/eos-live
 }
@@ -114,7 +132,10 @@ setup_overlay() {
 # Use persistent storage to back overlayfses, if available
 storage_partition=$(find_storage_partition)
 if [ -b "${storage_partition}" ]; then
+	echo "Found a device to back persistent storage: ${storage_partition}" >&2
 	setup_and_mount_storage "${storage_partition}"
+else
+	echo "Could not find a device to back persistent storage" >&2
 fi
 
 # If we booted and systemd was unable to find or create a machine-id,

--- a/eos-live-boot-overlayfs-setup
+++ b/eos-live-boot-overlayfs-setup
@@ -17,7 +17,7 @@ find_storage_partition() {
 		return 1
 	fi
 
-	local root_partition=$(blkid --output device --match-token "${bootdev}")
+	local root_partition=$(blkid --list-one --output device --match-token "${bootdev}")
 	if [ ! -b "${root_partition}" ] ; then
 		echo "String passed on endless.image.device does not represent a block device" >&2
 		return 1


### PR DESCRIPTION
If eos-image-boot-dm-setup.service has already run when this script
runs, blkid will return two devices matching the token passed via
endless.image.device, the real partition and the dm-device created by
eos-image-boot-dm-setup.

Limiting the output of blkid to one device only fixes a problem with the
logic in eos-live-boot-overlayfs-setup that was preventing
persistent.img from getting mapped when that happened, since it expects
only one device to be output.

https://phabricator.endlessm.com/T31223