### PR TITLE
chromium: Don't crash if .local/share/applications doesn't exist

### DIFF
--- a/eos-migrate-chromium-profile
+++ b/eos-migrate-chromium-profile
@@ -107,7 +107,12 @@ def update_desktop_shortcut(path):
 
 
 def update_desktop_shortcuts(path=DESKTOP_SHORTCUTS_DIR):
-    for filename in os.listdir(path):
+    try:
+        shortcuts = os.listdir(path)
+    except FileNotFoundError:
+        return
+
+    for filename in shortcuts:
         if filename.endswith(".desktop"):
             update_desktop_shortcut(os.path.join(path, filename))
 

--- a/eos-migrate-chromium-profile
+++ b/eos-migrate-chromium-profile
@@ -106,11 +106,10 @@ def update_desktop_shortcut(path):
     keyfile.save_to_file(path)
 
 
-def update_desktop_shortcuts():
-    for filename in os.listdir(DESKTOP_SHORTCUTS_DIR):
+def update_desktop_shortcuts(path=DESKTOP_SHORTCUTS_DIR):
+    for filename in os.listdir(path):
         if filename.endswith(".desktop"):
-            update_desktop_shortcut(os.path.join(DESKTOP_SHORTCUTS_DIR,
-                                                 filename))
+            update_desktop_shortcut(os.path.join(path, filename))
 
 
 def update_old_config_references(path):

--- a/tests/test_migrate_chromium_profile.py
+++ b/tests/test_migrate_chromium_profile.py
@@ -8,6 +8,7 @@ This test is based on test_migrate_firefox_profile.py.
 import tempfile
 import textwrap
 import os
+import unittest
 
 from .util import BaseTestCase, system_script, import_script_as_module
 
@@ -100,6 +101,13 @@ class TestUpdateDesktopShortcuts(BaseTestCase):
     def tearDown(self):
         self.tmp.cleanup()
 
+    @unittest.expectedFailure
+    def test_no_shortcuts_dir(self):
+        emfp.update_desktop_shortcuts(os.path.join(self.tmp.name, "no-such-directory"))
+
+    def test_empty_shortcuts_dir(self):
+        emfp.update_desktop_shortcuts(self.tmp.name)
+
     def test_not_there(self):
         orig_data = textwrap.dedent(
             """
@@ -134,7 +142,7 @@ class TestUpdateDesktopShortcuts(BaseTestCase):
         with open(test_desktop, "w") as f:
             f.write(orig_data)
 
-        emfp.update_desktop_shortcut(test_desktop)
+        emfp.update_desktop_shortcuts(self.tmp.name)
         with open(test_desktop, "r") as f:
             new_data = f.read()
 

--- a/tests/test_migrate_chromium_profile.py
+++ b/tests/test_migrate_chromium_profile.py
@@ -8,7 +8,6 @@ This test is based on test_migrate_firefox_profile.py.
 import tempfile
 import textwrap
 import os
-import unittest
 
 from .util import BaseTestCase, system_script, import_script_as_module
 
@@ -101,7 +100,6 @@ class TestUpdateDesktopShortcuts(BaseTestCase):
     def tearDown(self):
         self.tmp.cleanup()
 
-    @unittest.expectedFailure
     def test_no_shortcuts_dir(self):
         emfp.update_desktop_shortcuts(os.path.join(self.tmp.name, "no-such-directory"))
 


### PR DESCRIPTION
os.listdir() raises FileNotFoundError if the given directory doesn't
exist. Previously, eos-migrate-chromium-profile would crash in this
case, such as for every new user profile:

    Traceback (most recent call last):
      File "/usr/lib/eos-boot-helper/eos-migrate-chromium-profile", line 150, in <module>
        main()
      File "/usr/lib/eos-boot-helper/eos-migrate-chromium-profile", line 132, in main
        update_desktop_shortcuts()
      File "/usr/lib/eos-boot-helper/eos-migrate-chromium-profile", line 110, in update_desktop_shortcuts
        for filename in os.listdir(DESKTOP_SHORTCUTS_DIR):
    FileNotFoundError: [Errno 2] No such file or directory: '/sysroot/home/erikos/.local/share/applications'

In the case where the user had an old Chromium profile at
~/.config/chromium but no ~/.local/share/applications, this would mean
that their Chromium profile would not be migrated to the
Flatpak-compliant location.

https://phabricator.endlessm.com/T31446
