### PR TITLE
Remove xterm dependency

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -25,7 +25,6 @@ Description: Endless boot helper
 Depends: ${misc:Depends},
          dracut,
          xinit,
-         xterm,
          iptables,
          ostree,
          flatpak,

--- a/debian/control
+++ b/debian/control
@@ -24,7 +24,6 @@ Architecture: any
 Description: Endless boot helper
 Depends: ${misc:Depends},
          dracut,
-         xinit,
          iptables,
          ostree,
          flatpak,


### PR DESCRIPTION
This dep is not used by anything on eos-boot-helper.

https://phabricator.endlessm.com/T31519