### PR TITLE
eos-preset: Disable cni-dhcp.service

### DIFF
--- a/50-eos.preset
+++ b/50-eos.preset
@@ -12,6 +12,7 @@ disable systemd-networkd-wait-online.service
 disable apt-daily.timer
 disable apt-daily-upgrade.timer
 disable bluetooth-init.service
+disable cni-dhcp.service
 disable crio.service
 disable crio-shutdown.service
 disable cron.service


### PR DESCRIPTION
This service is shipped by containernetworking-plugins and does not need to be running in the OS. It also provides a .socket unit
which should auto-activate it if/when needed.