### PR TITLE
Add plumbing to add openh264 flatpak runtime to library search path when available

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -25,6 +25,9 @@ dist_systemdunit_DATA = \
 	eos-live-boot-overlayfs-setup.service \
 	eos-reclaim-swap.service \
 	eos-update-flatpak-repos.service \
+	flatpak-extension-runtime-fdo-openh264-ldconfig.service \
+	flatpak-extension-runtime-fdo-openh264-watcher.path \
+	flatpak-extension-runtime-fdo-openh264-watcher.service \
 	hack-remove-global-override.service \
 	$(NULL)
 
@@ -111,6 +114,7 @@ dist_tmpfiles_DATA = \
 	tmpfiles.d/avahi-service-writers.conf \
 	tmpfiles.d/chromium-system-services.conf \
 	tmpfiles.d/eos-boot-helper.conf \
+	tmpfiles.d/flatpak-extension-runtime-fdo-openh264.conf \
 	tmpfiles.d/flatpak-overrides.conf \
 	$(NULL)
 
@@ -119,3 +123,6 @@ dist_extratmpfiles_DATA = \
 	tmpfiles.d/flatpak-extension-kiwix-usb-content.conf \
 	$(NULL)
 
+ldconfdir = $(sysconfdir)/ld.so.conf.d
+dist_ldconf_DATA = \
+	ld.so.conf.d/flatpak-extension-runtime-fdo-openh264.conf

--- a/configure.ac
+++ b/configure.ac
@@ -105,6 +105,7 @@ AC_CONFIG_FILES([
 	dracut/image-boot/Makefile
 	dracut/repartition/Makefile
 	dracut/customization/Makefile
+	flatpak-extension-runtime-fdo-openh264-watcher.path
 	factory-reset/Makefile
 	fallback-fb-setup/Makefile
 	flatpak-repos/Makefile
@@ -113,5 +114,6 @@ AC_CONFIG_FILES([
 	record-boot-success/Makefile
 	tests/Makefile
 	tmpfiles.d/chromium-system-services.conf
+	tmpfiles.d/flatpak-extension-runtime-fdo-openh264.conf
 ])
 AC_OUTPUT

--- a/flatpak-extension-runtime-fdo-openh264-ldconfig.service
+++ b/flatpak-extension-runtime-fdo-openh264-ldconfig.service
@@ -1,0 +1,10 @@
+[Unit]
+After=systemd-tmpfiles-setup.service
+
+[Service]
+Type=oneshot
+RemainAfterExit=yes
+ExecStart=/sbin/ldconfig -X
+
+[Install]
+WantedBy=multi-user.target

--- a/flatpak-extension-runtime-fdo-openh264-watcher.path.in
+++ b/flatpak-extension-runtime-fdo-openh264-watcher.path.in
@@ -1,0 +1,8 @@
+[Unit]
+After=systemd-tmpfiles-setup.service
+
+[Path]
+PathChanged=/var/lib/flatpak/runtime/org.freedesktop.Platform.openh264/@FLATPAK_ARCH@/2.0/active/files/extra/libopenh264.so.6
+
+[Install]
+WantedBy=multi-user.target

--- a/flatpak-extension-runtime-fdo-openh264-watcher.service
+++ b/flatpak-extension-runtime-fdo-openh264-watcher.service
@@ -1,0 +1,9 @@
+[Unit]
+After=systemd-tmpfiles-setup.service
+
+[Service]
+Type=oneshot
+ExecStart=/usr/bin/systemctl restart flatpak-extension-runtime-fdo-openh264-ldconfig.service
+
+[Install]
+WantedBy=multi-user.target

--- a/ld.so.conf.d/flatpak-extension-runtime-fdo-openh264.conf
+++ b/ld.so.conf.d/flatpak-extension-runtime-fdo-openh264.conf
@@ -1,0 +1,1 @@
+/run/lib/openh264

--- a/tests/test_reclaim_swap.py
+++ b/tests/test_reclaim_swap.py
@@ -48,10 +48,10 @@ class TestReclaimSwap(BaseTestCase):
         '''
         lines = table.splitlines(keepends=True)
         out = []
-        for l in lines:
-            if l.startswith(b'Disk identifier:'):
+        for line in lines:
+            if line.startswith(b'Disk identifier:'):
                 continue
-            out.append(l)
+            out.append(line)
         return bytes().join(out)
 
     def run_test(self, test):

--- a/tmpfiles.d/flatpak-extension-runtime-fdo-openh264.conf.in
+++ b/tmpfiles.d/flatpak-extension-runtime-fdo-openh264.conf.in
@@ -1,0 +1,2 @@
+D /run/lib 0755 - - -
+L /run/lib/openh264 - - - - /var/lib/flatpak/runtime/org.freedesktop.Platform.openh264/@FLATPAK_ARCH@/2.0/active/files/extra


### PR DESCRIPTION
This change adds a tmpfiles.d config to link the openh264 flatpak runtime at /run/lib/openh264, a ld.so.conf.d config to make this dir available in the library search path and systemd units to re-run ldconfig when the runtime is installed/uninstalled in order to make it to the ldconfig cache.
    
We use a watcher service in order to re-run ldconfig (restart the unit responsible to run it) as path units can only start other units, not restart them.
    
https://phabricator.endlessm.com/T23316

