### PR TITLE
Migrate Freecell and Solitaire to Aisleriot, and fix a few other migrations

### DIFF
--- a/eos-update-flatpak-repos
+++ b/eos-update-flatpak-repos
@@ -1510,7 +1510,7 @@ COMMIT_BODY_INDEX = 4
 
 def copy_commit(repo, src_rev, dest_ref,
                 old_app_id=None, new_app_id=None,
-                collection_id=None, migrate_extra=False,
+                collection_id=None,
                 mangle_metadata=None):
     """Copy commit src_rev to dest_ref
     This makes the new commit at dest_ref have the proper collection
@@ -1631,12 +1631,6 @@ def migrate_extra_data(old_ref, new_ref):
         os.rename(new_extra + '.tmp', new_extra)
 
 
-def is_extra_data(repo, rev):
-    _, commit_variant, _ = repo.load_commit(rev)
-    commit_metadata = GLib.VariantDict.new(commit_variant.get_child_value(0))
-    return commit_metadata.contains('xa.extra-data-sources')
-
-
 def _migrate_installed_flatpaks():
     insts = Flatpak.get_system_installations()
     inst = insts[0]
@@ -1743,7 +1737,6 @@ def _migrate_installed_flatpaks():
                                  .format(old_ostree_ref,
                                          ostree_refs[old_ostree_ref],
                                          new_ostree_ref))
-                    migrate_extra = is_extra_data(repo, ostree_refs[old_ostree_ref])
                     repo.prepare_transaction()
                     try:
                         kwargs = {}
@@ -1751,7 +1744,6 @@ def _migrate_installed_flatpaks():
                         if kind == Flatpak.RefKind.APP:
                             kwargs['old_app_id'] = name
                             kwargs['new_app_id'] = new_name
-                            kwargs['migrate_extra'] = migrate_extra
                         new_commit, vendor_prefixes = copy_commit(
                             repo,
                             ostree_refs[old_ostree_ref],

--- a/eos-update-flatpak-repos
+++ b/eos-update-flatpak-repos
@@ -1251,6 +1251,24 @@ FLATPAKS_TO_MIGRATE = [
         "old-origin": "eos-apps",
         "new-origin": "flathub",
     },
+    {
+        "name": "org.gnome.Solitaire",
+        "new-name": "org.gnome.Aisleriot",
+        "kind": Flatpak.RefKind.APP,
+        "old-branch": "eos3",
+        "new-branch": "stable",
+        "old-origin": "eos-apps",
+        "new-origin": "flathub",
+    },
+    {
+        "name": "org.gnome.Freecell",
+        "new-name": "org.gnome.Aisleriot",
+        "kind": Flatpak.RefKind.APP,
+        "old-branch": "eos3",
+        "new-branch": "stable",
+        "old-origin": "eos-apps",
+        "new-origin": "flathub",
+    },
 ]
 
 

--- a/eos-update-flatpak-repos
+++ b/eos-update-flatpak-repos
@@ -1583,8 +1583,7 @@ def copy_commit(repo, src_rev, dest_ref,
     mtree = OSTree.MutableTree.new()
     repo.write_directory_to_mtree(src_root, mtree, None)
 
-    if old_app_id and new_app_id and \
-       (old_app_id != new_app_id or migrate_extra):
+    if old_app_id and new_app_id:
         metadata, vendor_prefixes = rewrite_metadata(repo, mtree, old_app_id,
                                                      new_app_id, mangle_metadata)
         commit_metadata.insert_value('xa.metadata',


### PR DESCRIPTION
These two apps were not previously migrated because they are both superseded by the same app, and we had wanted to make `org.gnome.Aisleriot.desktop` contain both in `X-Flatpak-RenamedFrom`.

I don't think this actually matters in practice, though. It will have the first one immediately, and then after being upgraded to the real Flathub version it will have both.

I also fixed a regression caused by a Flatpak becoming stricter, which broke the migration of at least 4 other apps.

https://phabricator.endlessm.com/T23936