### PR TITLE
eos-prune-printers: Add a service to prune printers

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -23,6 +23,7 @@ dist_systemdunit_DATA = \
 	eos-firstboot.service \
 	eos-image-boot-dm-setup.service \
 	eos-live-boot-overlayfs-setup.service \
+	eos-prune-printers.service \
 	eos-split-flatpak-repo.service \
 	eos-transient-setup.service \
 	eos-update-flatpak-repos.service \
@@ -99,6 +100,7 @@ dist_sbin_SCRIPTS = \
 	eos-firstboot \
 	eos-image-boot-dm-setup \
 	eos-live-boot-overlayfs-setup \
+	eos-prune-printers \
 	eos-repartition-mbr \
 	eos-split-flatpak-repo \
 	eos-transient-setup \

--- a/eos-prune-printers
+++ b/eos-prune-printers
@@ -1,0 +1,45 @@
+#!/usr/bin/env sh
+
+# eos-prune-printers: Purge all installed printers and corresponding drivers
+#
+# Copyright (C) 2021 Endless OS Foundation LLC
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License as
+# published by the Free Software Foundation; either version 2 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, see <http://www.gnu.org/licenses/>.
+
+# Exit if the stamp file exists. The service file checks for this, but also
+# guard against an accidental execution.
+stamp_file=/var/lib/eos4-prune-printers
+[ -e $stamp_file ] && exit 0
+
+# Purge and cancel all print jobs
+cancel -xa
+
+# Delete all printers with CUPS tool
+for printer in $(lpstat -p | awk '/^printer/{print $2}')
+do
+	echo Deleting "$printer"
+	lpadmin -x "$printer"
+done
+
+# Remove the printer drivers and residual print cache files
+systemctl stop cups
+
+# remove stamp file from eos-config-printer (from 4.0 use driverless printers)
+rm -rf /var/lib/eos-config-printer
+# clean up the residual print cache files
+rm -rf /var/cache/cups/*
+
+systemctl start cups
+
+touch $stamp_file

--- a/eos-prune-printers.service
+++ b/eos-prune-printers.service
@@ -1,0 +1,14 @@
+[Unit]
+Description=Endless prune printers
+After=cups.service
+Requires=cups.service
+ConditionPathExists=!/var/lib/eos4-printers-pruned
+ConditionKernelCommandLine=!endless.live_boot
+
+[Service]
+Type=oneshot
+ExecStart=/usr/sbin/eos-prune-printers
+StandardOutput=journal
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
EOS 4 will change printer mechanism to driverless. So, there will be
transition action when users' computer upgrade from eos3a to eos4.
Add eos-prune-printers.servive to prune the installed printers and
drivers.

https://phabricator.endlessm.com/T31862