### PR TITLE
Use repo locking when splitting flatpak repo

### DIFF
--- a/eos-split-flatpak-repo
+++ b/eos-split-flatpak-repo
@@ -52,8 +52,12 @@ def set_repo_path_attr(repo):
     repo.path = os.path.realpath(repo.get_path().get_path())
 
 
-def duplicate_dir(src, dst):
-    """Duplicate a directory with hard links"""
+def duplicate_repo(src, dst):
+    """Duplicate an OSTree repo with hard links where appropriate
+
+    All commit data is copied with hard links while other repository
+    metadata is duplicated.
+    """
     try:
         if os.path.islink(dst):
             logger.debug('Deleting symlink %s', dst)
@@ -64,9 +68,29 @@ def duplicate_dir(src, dst):
     except FileNotFoundError:
         pass
 
+    def _copy_ostree_file(a, b):
+        # For actual commit data in objects or deltas, use a hardlink.
+        # For everything else, make a copy to ensure the repos don't
+        # operate on each other's metadata.
+        #
+        # Potentially some fetched but not committed objects in tmp
+        # would be useful to link, but it's mixed with other data that
+        # might not be safe to link.
+        src_path_parts = os.path.relpath(a, src).split(os.sep)
+        if len(src_path_parts) > 1:
+            src_repodir = src_path_parts[0]
+        else:
+            src_repodir = None
+        if src_repodir in ('objects', 'deltas'):
+            logger.debug('Linking %s to %s', a, b)
+            return os.link(a, b)
+
+        logger.debug('Copying %s to %s', a, b)
+        return shutil.copy2(a, b)
+
     logger.debug('Duplicating %s to %s', src, dst)
     os.makedirs(os.path.dirname(dst), exist_ok=True)
-    shutil.copytree(src, dst, symlinks=True, copy_function=os.link)
+    shutil.copytree(src, dst, symlinks=True, copy_function=_copy_ostree_file)
 
 
 @contextmanager
@@ -292,7 +316,7 @@ def split_repo(prune=False, root='/'):
                 os.path.dirname(ostree_repo.path), 'new-flatpak-repo')
             logger.info('Creating new Flatpak repo at %s',
                         new_flatpak_repo_path)
-            duplicate_dir(ostree_repo.path, new_flatpak_repo_path)
+            duplicate_repo(ostree_repo.path, new_flatpak_repo_path)
             new_flatpak_repo = OSTree.Repo.new(
                 Gio.File.new_for_path(new_flatpak_repo_path))
             new_flatpak_repo.open()

--- a/eos-split-flatpak-repo
+++ b/eos-split-flatpak-repo
@@ -96,11 +96,13 @@ def duplicate_repo(src, dst):
 @contextmanager
 def repo_lock(repo, lock_type):
     """OSTree repo lock context"""
-    # FIXME: Fill this in when repo locking is public
-    # https://github.com/ostreedev/ostree/issues/2286
     logger.info('Locking repo %s', repo.path)
-    yield
-    logger.info('Unlocking repo %s', repo.path)
+    repo.lock_push(lock_type)
+    try:
+        yield
+    finally:
+        logger.info('Unlocking repo %s', repo.path)
+        repo.lock_pop(lock_type)
 
 
 @contextmanager
@@ -310,7 +312,7 @@ def split_repo(prune=False, root='/'):
         changed = True
 
         # Lock the current repo
-        with repo_lock(ostree_repo, 'exclusive'):
+        with repo_lock(ostree_repo, OSTree.RepoLockType.EXCLUSIVE):
             # Create the new flatpak repo
             new_flatpak_repo_path = os.path.join(
                 os.path.dirname(ostree_repo.path), 'new-flatpak-repo')
@@ -323,7 +325,7 @@ def split_repo(prune=False, root='/'):
             set_repo_path_attr(new_flatpak_repo)
 
             # Lock the new repo
-            with repo_lock(new_flatpak_repo, 'exclusive'):
+            with repo_lock(new_flatpak_repo, OSTree.RepoLockType.EXCLUSIVE):
                 # Gather the remotes
                 logger.info('Gathering OS and Flatpak remotes')
                 os_remotes, flatpak_remotes = gather_remotes(ostree_repo)

--- a/tests/test_split_flatpak_repo.py
+++ b/tests/test_split_flatpak_repo.py
@@ -66,6 +66,13 @@ class TestSplitRepo(BaseTestCase):
         self.os_repo_path = os.path.realpath(
             self.os_repo.get_path().get_path())
 
+        # Set the repo locking timeout to 0 seconds so that locking
+        # failures don't block tests.
+        config = self.os_repo.copy_config()
+        config.set_integer('core', 'lock-timeout-secs', 0)
+        self.os_repo.write_config(config)
+        self.os_repo.reload_config()
+
         # /sysroot/ostree
         self.ostree_path = os.path.dirname(self.os_repo_path)
         # /ostree

--- a/tests/test_split_flatpak_repo.py
+++ b/tests/test_split_flatpak_repo.py
@@ -23,6 +23,7 @@
 Tests eos-split-flatpak-repo
 """
 
+import filecmp
 import gi
 import logging
 import os
@@ -443,3 +444,38 @@ class TestSplitRepo(BaseTestCase):
         with self.assertRaisesRegex(esfr.SplitError,
                                     'eos in both OS and Flatpak remotes'):
             esfr.gather_refs(self.os_repo, os_remotes, flatpak_remotes)
+
+    def assertDircmpNoDiffs(self, dircmp):
+        """Recursively assert that a dircmp object has no differences"""
+        logger.debug("Comparing %s to %s", dircmp.left, dircmp.right)
+        self.assertEqual(dircmp.left_only, [])
+        self.assertEqual(dircmp.right_only, [])
+        self.assertEqual(dircmp.diff_files, [])
+
+        for sub in dircmp.subdirs.values():
+            self.assertDircmpNoDiffs(sub)
+
+    def test_duplicate_repo(self):
+        """Test duplicate_repo functionality"""
+        self.create_os_commits()
+        self.create_flatpak_commits()
+
+        dup_path = os.path.join(self.tmp, 'dup')
+        esfr.duplicate_repo(self.os_repo_path, dup_path)
+
+        # The directories should be identical.
+        dcmp = filecmp.dircmp(self.os_repo_path, dup_path, ignore=[])
+        self.assertDircmpNoDiffs(dcmp)
+
+        # Make sure the number of hardlinks is correct.
+        for root, dirs, files in os.walk(dup_path):
+            repo_dir = os.path.relpath(root, dup_path).split(os.sep)[0]
+            if repo_dir in ('objects', 'deltas'):
+                expected_links = 2
+            else:
+                expected_links = 1
+            for f in files:
+                path = os.path.join(root, f)
+                logger.debug('Getting number of links for %s', path)
+                stat = os.lstat(path)
+                self.assertEqual(stat.st_nlink, expected_links)


### PR DESCRIPTION
Wire up the OSTree repo locking now that the API is available. That immediately deadlocked because the `.lock` file was being hardlinked to the new repo, so the hardlinking is reduced to just the objects and (likely nonexistent) deltas. Everything else is copied.

https://phabricator.endlessm.com/T32090