### PR TITLE
eos-prune-printers: Fix the service's condition & requirements

### DIFF
--- a/eos-prune-printers
+++ b/eos-prune-printers
@@ -36,9 +36,22 @@ done
 systemctl stop cups
 
 # remove stamp file from eos-config-printer (from 4.0 use driverless printers)
-rm -rf /var/lib/eos-config-printer
+LIB_CONFIG_PRINTER=/var/lib/eos-config-printer
+if [ -d $LIB_CONFIG_PRINTER ]; then
+	echo Removing $LIB_CONFIG_PRINTER
+	rm -rf $LIB_CONFIG_PRINTER
+else
+	echo $LIB_CONFIG_PRINTER does not exist
+fi
+
 # clean up the residual print cache files
-rm -rf /var/cache/cups/*
+CACHE_CUPS=/var/cache/cups
+if [ -d $CACHE_CUPS ]; then
+	echo Removing "$CACHE_CUPS/*"
+	rm -rf ${CACHE_CUPS:?}/*
+else
+	echo $CACHE_CUPS does not exist
+fi
 
 systemctl start cups
 

--- a/eos-prune-printers.service
+++ b/eos-prune-printers.service
@@ -1,8 +1,8 @@
 [Unit]
 Description=Endless prune printers
 After=cups.service
-Requires=cups.service
-ConditionPathExists=!/var/lib/eos4-printers-pruned
+Wants=cups.service
+ConditionPathExists=!/var/lib/eos4-prune-printers
 ConditionKernelCommandLine=!endless.live_boot
 
 [Service]


### PR DESCRIPTION
1. Fix the conflicted cups.service requirement by removing it. Because,
   the script needs to stop it temporarily.
2. Sync the service's condition guard stamp filename with the script's.
3. Check the directories exist before remove them and their content.

https://phabricator.endlessm.com/T31862