### PR TITLE
eos-preset: Do not disable systemd-timesyncd

### DIFF
--- a/50-eos.preset
+++ b/50-eos.preset
@@ -3,7 +3,6 @@
 # desired. All others will be enabled by systemd.
 
 # Reverse systemd defaults
-disable systemd-timesyncd.service
 disable systemd-networkd.service
 disable systemd-resolved.service
 disable systemd-networkd-wait-online.service


### PR DESCRIPTION
We are switching from ntp to the simpler systemd-timesyncd.

https://phabricator.endlessm.com/T16376