### PR TITLE
eos-vm-generator: Enable virtualbox-guest-utils via generator

### DIFF
--- a/50-eos.preset
+++ b/50-eos.preset
@@ -46,6 +46,13 @@ disable wpa_supplicant-nl80211@.service
 disable wpa_supplicant-wired@.service
 disable xl2tpd.service
 
+# Disable virtualbox-guest-utils.service by default. It will be enabled
+# dynamically by eos-vm-generator when running in virtualbox.
+# ConditionVirtualization=oracle on the unit is not enought as it will
+# prevent conflicted units (systemd-timesyncd.service) from starting.
+# https://phabricator.endlessm.com/T32330#906081
+disable virtualbox-guest-utils.service
+
 # Disable units masked by Debian, as systemctl preset-all fails to
 # handle them. Without this, `systemctl preset-all` will fail with:
 #

--- a/Makefile.am
+++ b/Makefile.am
@@ -41,6 +41,7 @@ dist_systemduserunit_DATA = \
 
 dist_systemdgenerator_SCRIPTS = \
 	eos-live-boot-generator \
+	eos-vm-generator \
 	$(NULL)
 
 dist_systemdpreset_DATA = \

--- a/eos-vm-generator
+++ b/eos-vm-generator
@@ -1,0 +1,20 @@
+#!/bin/sh
+#
+# Usage: eos-vm-generator normal-dir [...]
+#
+# Conditionally adds additional boot dependencies for vm boots.
+# This script implements systemd.generator(7).
+
+dest_dir="${1:?normal-dir argument missing}"
+system_dir=/usr/lib/systemd/system
+multi_user_target_wants_dir="$dest_dir/multi-user.target.wants"
+
+# Only run on virtualbox
+vm_string=$(/usr/bin/systemd-detect-virt)
+if [ "$vm_string" != "oracle" ] ; then
+  exit 0
+fi
+
+unit_path="$system_dir/virtualbox-guest-utils.service"
+mkdir -p "$multi_user_target_wants_dir"
+ln -sf "$unit_path" "$multi_user_target_wants_dir/"


### PR DESCRIPTION
We need to enable virtualbox-guest-utils dynamically via a generator,
since ConditionVirtualization=oracle on the unit is not enought because
it will prevent conflicted units (systemd-timesyncd.service) from
starting.

https://phabricator.endlessm.com/T32330