### PR TITLE
eos-preset: Disable checkbox-ng by default

### DIFF
--- a/50-eos.preset
+++ b/50-eos.preset
@@ -11,6 +11,7 @@ disable systemd-networkd-wait-online.service
 disable apt-daily.timer
 disable apt-daily-upgrade.timer
 disable bluetooth-init.service
+disable checkbox-ng.service
 disable cni-dhcp.service
 disable crio.service
 disable crio-shutdown.service


### PR DESCRIPTION
Disable checkbox-ng.service by default. This avoids running on normal
users' system, which might be used as backdoor.

https://phabricator.endlessm.com/T32197