### PR TITLE
Remove dead code from eos-transient-setup

### DIFF
--- a/eos-transient-setup
+++ b/eos-transient-setup
@@ -17,7 +17,6 @@
 # 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
 import argparse
-import enum
 import glob
 import json
 import logging
@@ -55,11 +54,6 @@ FAVORITE_APPS_KEY = 'favorite-apps'
 GS_SCHEMA = 'org.gnome.software'
 ALLOW_UPDATES = 'allow-updates'
 
-# The other mode here (demo mode) was removed with the rebase to 3.38. The
-# --mode argument has been kept around to maintain CLI API compatibility.
-class Mode(enum.Enum):
-    live = 1
-
 
 class AdjustGSettings(object):
     def __init__(self):
@@ -71,9 +65,9 @@ class AdjustGSettings(object):
         log.info('Updating %s: %s to %s', schema, key, value)
         self.keyfile.set_string(schema.replace('.', '/'), key, value)
 
-    def prepare(self, mode):
+    def prepare(self):
         """Stage all settings to be overridden."""
-        self.update_favorite_apps(mode)
+        self.update_favorite_apps()
         self.disallow_app_center_updates()
 
     def write_dconf_compile(self):
@@ -102,21 +96,17 @@ class AdjustGSettings(object):
         data, length = self.keyfile.to_data()
         print(data)
 
-    def update_favorite_apps(self, mode):
+    def update_favorite_apps(self):
         """Adjust default favourite apps, which are shown on the taskbar."""
         settings = Gio.Settings(schema=SHELL_SCHEMA)
         favorite_apps = settings.get_strv(FAVORITE_APPS_KEY)
-        changed = False
 
-        if mode == Mode.live:
-            # Prepend installer icon
-            if EOS_INSTALLER not in favorite_apps:
-                favorite_apps.insert(0, EOS_INSTALLER)
-                changed = True
+        # Prepend installer icon
+        if EOS_INSTALLER not in favorite_apps:
+            favorite_apps.insert(0, EOS_INSTALLER)
 
-        if changed:
-            self.update(SHELL_SCHEMA, FAVORITE_APPS_KEY,
-                        GLib.Variant('as', favorite_apps))
+        self.update(SHELL_SCHEMA, FAVORITE_APPS_KEY,
+                    GLib.Variant('as', favorite_apps))
 
     def disallow_app_center_updates(self):
         """Forbid installing app updates."""
@@ -186,13 +176,9 @@ def reduce_ostree_min_free_space():
 def main():
     """Configures system settings for live sessions."""
     p = argparse.ArgumentParser(description=main.__doc__)
-    p.add_argument('--mode', choices=[m.name for m in Mode], required=True,
-                   default='live',
-                   help='Whether to adjust settings for live mode')
     p.add_argument('--dry-run', action='store_true',
                    help='Just print the DConf keyfile to stdout')
     a = p.parse_args()
-    mode = Mode[a.mode]
 
     logging.basicConfig(
         level=logging.INFO,
@@ -200,7 +186,7 @@ def main():
                '%(message)s')
 
     setup = AdjustGSettings()
-    setup.prepare(mode=mode)
+    setup.prepare()
 
     if a.dry_run:
         setup.write_stdout()
@@ -208,10 +194,8 @@ def main():
         setup.write_dconf_compile()
 
         reduce_ostree_min_free_space()
-
-        if mode == Mode.live:
-            install_installer_desktop_file()
-            prepend_installer_to_icon_grid()
+        install_installer_desktop_file()
+        prepend_installer_to_icon_grid()
 
 
 if __name__ == '__main__':

--- a/eos-transient-setup
+++ b/eos-transient-setup
@@ -75,21 +75,21 @@ class AdjustGSettings:
 
         We also adjust the 'user' profile to use it.
         """
-        with tempfile.TemporaryDirectory(suffix='.d') as d:
-            keyfile_path = os.path.join(d, '00-live')
+        with tempfile.TemporaryDirectory(suffix='.d') as tempdir:
+            keyfile_path = os.path.join(tempdir, '00-live')
             log.info('writing keyfile to %s', keyfile_path)
             self.keyfile.save_to_file(keyfile_path)
 
             os.makedirs(os.path.dirname(LIVE_SETTINGS_DB), exist_ok=True)
 
-            args = ['dconf', 'compile', LIVE_SETTINGS_DB, d]
+            args = ['dconf', 'compile', LIVE_SETTINGS_DB, tempdir]
             log.info('$ %s', ' '.join(args))
             subprocess.check_call(args)
 
         log.info('Installing new DConf profile to %s', USER_PROFILE_PATH)
         os.makedirs(os.path.dirname(USER_PROFILE_PATH), exist_ok=True)
-        with open(USER_PROFILE_PATH, 'w') as f:
-            f.write(USER_PROFILE)
+        with open(USER_PROFILE_PATH, 'w') as user_profile_file:
+            user_profile_file.write(USER_PROFILE)
 
     def write_stdout(self):
         """Write keyfile with overridden settings to stdout, for debugging."""
@@ -124,12 +124,13 @@ def install_installer_desktop_file():
              EOS_INSTALLER_PATH, LOCAL_DESKTOP_PATH)
     os.makedirs(LOCAL_APPS_DIR, exist_ok=True)
 
-    kf = GLib.KeyFile()
-    kf.load_from_file(EOS_INSTALLER_PATH,
-                      GLib.KeyFileFlags.KEEP_COMMENTS |
-                      GLib.KeyFileFlags.KEEP_TRANSLATIONS)
-    kf.remove_key('Desktop Entry', 'NoDisplay')
-    kf.save_to_file(LOCAL_DESKTOP_PATH)
+    eos_installer_desktop = GLib.KeyFile()
+    eos_installer_desktop.load_from_file(
+        EOS_INSTALLER_PATH,
+        GLib.KeyFileFlags.KEEP_COMMENTS | GLib.KeyFileFlags.KEEP_TRANSLATIONS,
+    )
+    eos_installer_desktop.remove_key('Desktop Entry', 'NoDisplay')
+    eos_installer_desktop.save_to_file(LOCAL_DESKTOP_PATH)
 
 
 def prepend_installer_to_icon_grid():
@@ -143,9 +144,9 @@ def prepend_installer_to_icon_grid():
     for path in paths:
         try:
             try:
-                with open(path, 'r') as f:
+                with open(path, 'r') as grid_file:
                     log.info("reading existing file %s", path)
-                    grid = json.load(fp=f)
+                    grid = json.load(fp=grid_file)
             except FileNotFoundError:
                 grid = {}
 
@@ -154,8 +155,8 @@ def prepend_installer_to_icon_grid():
                 desktop.insert(0, EOS_INSTALLER)
 
                 log.info("Writing %s: %s", path, json.dumps(obj=grid))
-                with open(path, 'w') as f:
-                    json.dump(obj=grid, fp=f)
+                with open(path, 'w') as grid_file:
+                    json.dump(obj=grid, fp=grid_file)
         except Exception:
             log.exception("while processing %s", path)
 
@@ -175,10 +176,13 @@ def reduce_ostree_min_free_space():
 
 def main():
     """Configures system settings for live sessions."""
-    p = argparse.ArgumentParser(description=main.__doc__)
-    p.add_argument('--dry-run', action='store_true',
-                   help='Just print the DConf keyfile to stdout')
-    a = p.parse_args()
+    parser = argparse.ArgumentParser(description=main.__doc__)
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Just print the DConf keyfile to stdout",
+    )
+    args = parser.parse_args()
 
     logging.basicConfig(
         level=logging.INFO,
@@ -188,7 +192,7 @@ def main():
     setup = AdjustGSettings()
     setup.prepare()
 
-    if a.dry_run:
+    if args.dry_run:
         setup.write_stdout()
     else:
         setup.write_dconf_compile()

--- a/eos-transient-setup
+++ b/eos-transient-setup
@@ -93,7 +93,7 @@ class AdjustGSettings:
 
     def write_stdout(self):
         """Write keyfile with overridden settings to stdout, for debugging."""
-        data, length = self.keyfile.to_data()
+        data, _ = self.keyfile.to_data()
         print(data)
 
     def update_favorite_apps(self):

--- a/eos-transient-setup
+++ b/eos-transient-setup
@@ -55,15 +55,6 @@ FAVORITE_APPS_KEY = 'favorite-apps'
 GS_SCHEMA = 'org.gnome.software'
 ALLOW_UPDATES = 'allow-updates'
 
-GSD_POWER_SCHEMA = "org.gnome.settings-daemon.plugins.power"
-GSD_SLEEP_INACTIVE_AC_TYPE = "sleep-inactive-ac-type"
-GSD_SLEEP_INACTIVE_AC_TIMEOUT = "sleep-inactive-ac-timeout"
-GSD_SLEEP_INACTIVE_BATTERY_TYPE = "sleep-inactive-battery-type"
-GSD_SLEEP_INACTIVE_BATTERY_TIMEOUT = "sleep-inactive-battery-timeout"
-
-ONE_MINUTE = 60
-
-
 # The other mode here (demo mode) was removed with the rebase to 3.38. The
 # --mode argument has been kept around to maintain CLI API compatibility.
 class Mode(enum.Enum):
@@ -110,18 +101,6 @@ class AdjustGSettings(object):
         """Write keyfile with overridden settings to stdout, for debugging."""
         data, length = self.keyfile.to_data()
         print(data)
-
-    def adjust_power_settings(self):
-        """Configure session to log out after a short period of inactivity."""
-        for key in (GSD_SLEEP_INACTIVE_AC_TYPE,
-                    GSD_SLEEP_INACTIVE_BATTERY_TYPE):
-            self.update(GSD_POWER_SCHEMA, key,
-                        GLib.Variant('s', 'logout'))
-
-        for key in (GSD_SLEEP_INACTIVE_AC_TIMEOUT,
-                    GSD_SLEEP_INACTIVE_BATTERY_TIMEOUT):
-            self.update(GSD_POWER_SCHEMA, key,
-                        GLib.Variant('i', ONE_MINUTE))
 
     def update_favorite_apps(self, mode):
         """Adjust default favourite apps, which are shown on the taskbar."""

--- a/eos-transient-setup
+++ b/eos-transient-setup
@@ -27,6 +27,7 @@ import tempfile
 
 import gi
 gi.require_version('OSTree', '1.0')
+# pylint: disable=wrong-import-position
 from gi.repository import GLib, Gio, OSTree  # noqa: E402
 
 log = logging.getLogger(sys.argv[0])

--- a/eos-transient-setup
+++ b/eos-transient-setup
@@ -55,7 +55,7 @@ GS_SCHEMA = 'org.gnome.software'
 ALLOW_UPDATES = 'allow-updates'
 
 
-class AdjustGSettings(object):
+class AdjustGSettings:
     def __init__(self):
         self.keyfile = GLib.KeyFile()
 

--- a/eos-transient-setup.service
+++ b/eos-transient-setup.service
@@ -6,7 +6,7 @@ ConditionKernelCommandLine=endless.live_boot
 
 [Service]
 Type=oneshot
-ExecStart=/usr/sbin/eos-transient-setup --mode live
+ExecStart=/usr/sbin/eos-transient-setup
 RemainAfterExit=yes
 
 [Install]


### PR DESCRIPTION
This script has many vestiges of a time when demo mode existed, but that time is long behind us. Remove the dead code and command-line option. Spotted while reviewing #354.

Then while I was here I decided to run `pylint` over the file and fix most of the warnings. We are left with:

```
************* Module eos-transient-setup
eos-transient-setup:1:0: C0103: Module name "eos-transient-setup" doesn't conform to snake_case naming style (invalid-name)
eos-transient-setup:1:0: C0114: Missing module docstring (missing-module-docstring)
eos-transient-setup:59:0: C0115: Missing class docstring (missing-class-docstring)
eos-transient-setup:161:15: W0703: Catching too general exception Exception (broad-except)
```

Legit (except the first one) but ones for another day.

I haven't tested it "for real" but I have tested that `--dry-run` succeeds and that running without `--dry-run` as my own user fails because it can't write to `/var`, and that `flake8` is still happy.