### PR TITLE
eos-preset: Disable systemd-sysusers by default

### DIFF
--- a/50-eos.preset
+++ b/50-eos.preset
@@ -6,6 +6,7 @@
 disable systemd-networkd.service
 disable systemd-resolved.service
 disable systemd-networkd-wait-online.service
+disable systemd-sysusers.service
 
 # Disable other unwanted units
 disable apt-daily.timer


### PR DESCRIPTION
EOS maintains system users by customed base-passwd directly, instead of
systemd-sysusers currently. To avoid systemd-sysusers trying to have
duplicated system users from the customed basic.conf in base-passwd
package and showing the confliction messages, this patch disables
systemd-sysusers service.

https://phabricator.endlessm.com/T31589