### PR TITLE
Revert "eos-preset: Disable systemd-sysusers by default"

### DIFF
--- a/50-eos.preset
+++ b/50-eos.preset
@@ -6,7 +6,6 @@
 disable systemd-networkd.service
 disable systemd-resolved.service
 disable systemd-networkd-wait-online.service
-disable systemd-sysusers.service
 
 # Disable other unwanted units
 disable apt-daily.timer


### PR DESCRIPTION
This reverts commit e37cd5d85d2ee38c63838137fc8d218fde564e21.

Systemd-sysusers is a static unit. Disabling it does not disable others
invoking it. So, revert the commit.

https://phabricator.endlessm.com/T31589