### PR TITLE
preset: Disable unwanted podman service & timer

### DIFF
--- a/50-eos.preset
+++ b/50-eos.preset
@@ -31,6 +31,8 @@ disable openvpn-client@.service
 disable openvpn-server@.service
 disable openvpn.service
 disable openvpn@.service
+disable podman-auto-update.service
+disable podman-auto-update.timer
 disable pppd-dns.service
 disable rtkit-daemon.service
 disable rsyslog.service


### PR DESCRIPTION
This service updates any root-owned containers which have been manually
tagged to be automatically updated. This is not needed by a typical
Endless OS user.

https://phabricator.endlessm.com/T32795
