### PR TITLE
split-flatpak-repo: Run service in background

### DIFF
--- a/eos-split-flatpak-repo.service
+++ b/eos-split-flatpak-repo.service
@@ -1,20 +1,23 @@
 [Unit]
 Description=Split Flatpak repo from system OSTree repo
-DefaultDependencies=no
-Conflicts=shutdown.target
-Wants=local-fs.target
-After=local-fs.target
 
 # This is only needed when the flatpak dir or repo is a symlink
 ConditionPathIsSymbolicLink=|/var/lib/flatpak
 ConditionPathIsSymbolicLink=|/var/lib/flatpak/repo
 
-# Try to run before any ostree and flatpak clients so that the repo can
-# be exclusively locked.
+# We want the best chance that the OSTree sysroot and repo can be
+# exclusively locked. Ideally we'd run before all of these services, but
+# some of them block boot and run before the DBus system socket is up,
+# which means metrics can't be used.
+After=eos-update-flatpak-repos.service
+After=eos-updater-flatpak-installer.service
 Before=eos-autoupdater.service eos-updater.service
-Before=eos-update-flatpak-repos.service
 Before=eos-updater-avahi.service eos-update-server.service
-Before=eos-updater-flatpak-installer.service
+Before=eos-updater-flatpak-installer-fallback.service
+
+# Run before the flatpak system helper so it doesn't open the
+# installation before it's swapped.
+Before=flatpak-system-helper.service
 
 [Service]
 Type=oneshot


### PR DESCRIPTION
Since `eos-update-flatpak-repos.service` and
`eos-updater-flatpak-installer.service` block boot via
`systemd-update-done.service`, ordering before them means that
`eos-split-flatpak-repos.service` blocks boot for a potentially very
long time.

Instead, order after those services and before any others that open the
system OSTree repo or the system Flatpak installation. By also reverting
to `DefaultDependencies=yes`, this service can run in the background
while the desktop is up. Of course, any system OSTree or Flatpak
operations will fail, but the system is otherwise usable.

This also allows the metrics to work since otherwise the service runs
befor the system DBus socket exists.

https://phabricator.endlessm.com/T32768