### PR TITLE
split-flatpak-repo: Use idle IO scheduling class

### DIFF
--- a/eos-split-flatpak-repo.service
+++ b/eos-split-flatpak-repo.service
@@ -23,6 +23,7 @@ Before=flatpak-system-helper.service
 Type=oneshot
 RemainAfterExit=true
 ExecStart=/usr/sbin/eos-split-flatpak-repo
+IOSchedulingClass=idle
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
Now that the service is running in the background, it would be better to
lower the IO priority so that the user gets to the desktop faster. Even
though they'll be blocked from using OSTree and Flatpak longer, being
able to see the desktop and use parts of it is a better indication that
the computer isn't broken.

https://phabricator.endlessm.com/T32768