### PR TITLE
tmpfiles: Don't empty directories

### DIFF
--- a/tmpfiles.d/chromium-system-services.conf.in
+++ b/tmpfiles.d/chromium-system-services.conf.in
@@ -1,7 +1,7 @@
-D /etc/chromium-browser 0755 - - -
-D /run/flatpak/extension/org.chromium.Chromium.Policy.system-policies 0755 - - -
-D /run/flatpak/extension/org.chromium.Chromium.Policy.system-policies/@FLATPAK_ARCH@ 0755 - - -
+d /etc/chromium-browser 0755 - - -
+d /run/flatpak/extension/org.chromium.Chromium.Policy.system-policies 0755 - - -
+d /run/flatpak/extension/org.chromium.Chromium.Policy.system-policies/@FLATPAK_ARCH@ 0755 - - -
 L /run/flatpak/extension/org.chromium.Chromium.Policy.system-policies/@FLATPAK_ARCH@/1 - - - - /etc/chromium-browser
-D /run/flatpak/extension/org.chromium.Chromium.Extension.system-extensions 0755 - - -
-D /run/flatpak/extension/org.chromium.Chromium.Extension.system-extensions/@FLATPAK_ARCH@ 0755 - - -
+d /run/flatpak/extension/org.chromium.Chromium.Extension.system-extensions 0755 - - -
+d /run/flatpak/extension/org.chromium.Chromium.Extension.system-extensions/@FLATPAK_ARCH@ 0755 - - -
 L /run/flatpak/extension/org.chromium.Chromium.Extension.system-extensions/@FLATPAK_ARCH@/1 - - - - /usr/share/chromium

--- a/tmpfiles.d/flatpak-extension-kiwix-usb-content.conf
+++ b/tmpfiles.d/flatpak-extension-kiwix-usb-content.conf
@@ -1,3 +1,3 @@
-D /run/flatpak/extension/com.endlessm.encyclopedia.en.Content/x86_64 0755 - - -
+d /run/flatpak/extension/com.endlessm.encyclopedia.en.Content/x86_64 0755 - - -
 L /run/flatpak/extension/com.endlessm.encyclopedia.en.Content/x86_64/eos3 - - - - /run/media/eoslive/.kiwix/flatpak
 L /var/lib/flatpak/extension - - - - /run/flatpak/extension

--- a/tmpfiles.d/flatpak-overrides.conf
+++ b/tmpfiles.d/flatpak-overrides.conf
@@ -1,2 +1,2 @@
-D /run/flatpak/overrides 0755 - - -
+d /run/flatpak/overrides 0755 - - -
 L /var/lib/flatpak/overrides - - - - /run/flatpak/overrides


### PR DESCRIPTION
Per tmpfiles.d(5), the `D` directive empties the contents of the
directory when `systemd-tmpfiles` is run with `--remove`. This happens
on every boot from `systemd-tmpfiles-setup.service`, so all of these
directories were being emptied during boot. In many cases that's
probably harmless, but for `/etc/chromium-browser`, it deletes all
chromium system configuration.

https://phabricator.endlessm.com/T32863