### PR TITLE
nvidia-graphics-setup: Make egl-wayland use PRIME render offload

### DIFF
--- a/nvidia/nvidia-graphics-setup
+++ b/nvidia/nvidia-graphics-setup
@@ -195,6 +195,10 @@ if ! modprobe -c | grep -F -x --quiet "blacklist nvidia" &&
   load_module "${MODULE_DIR}"/nvidia-drm.ko modeset=1
   first_boot_cleanup_modules
   if [[ -e "/sys/module/nvidia_drm" ]]; then
+    # Use PRIME render offloading to NVIDIA device by setting the environment
+    # vairable __NV_PRIME_RENDER_OFFLOAD for egl-wayland, T33814
+    systemctl set-environment __NV_PRIME_RENDER_OFFLOAD=1
+
     echo "nvidia loaded successfully"
     exit 0
   fi


### PR DESCRIPTION
The egl-wayland failed to choose the NVIDIA device for rendering and
chooses the internal GPU as the fallback since 1.1.10. This patch sets
the environment variable __NV_PRIME_RENDER_OFFLOAD to tell egl-wayland
choosing the NVIDIA GPU as the EGL device for rendering as past when the
nvidia driver is loaded for the NVIDIA device.

https://phabricator.endlessm.com/T33814