### PR TITLE
Add service to set ostree bootloader on existing systems

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -24,6 +24,7 @@ dist_systemdunit_DATA = \
 	eos-firstboot.service \
 	eos-image-boot-dm-setup.service \
 	eos-live-boot-overlayfs-setup.service \
+	eos-ostree-bootloader-setup.service \
 	eos-prune-printers.service \
 	eos-split-flatpak-repo.service \
 	eos-transient-setup.service \
@@ -93,6 +94,7 @@ dist_sbin_SCRIPTS = \
 	eos-firstboot \
 	eos-image-boot-dm-setup \
 	eos-live-boot-overlayfs-setup \
+	eos-ostree-bootloader-setup \
 	eos-prune-printers \
 	eos-repartition-mbr \
 	eos-split-flatpak-repo \

--- a/eos-ostree-bootloader-setup
+++ b/eos-ostree-bootloader-setup
@@ -1,0 +1,38 @@
+#!/bin/sh
+
+# eos-ostree-bootloader-setup: Set OSTree sysroot bootloader configuration
+#
+# Copyright © 2022 Endless OS Foundation LLC
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or (at
+# your option) any later version.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+# General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+# 02110-1301, USA.
+
+set -e
+
+# If the option is already set, leave it alone.
+if ostree config get sysroot.bootloader >/dev/null 2>&1; then
+    exit 0
+fi
+
+# If uEnv.txt exists, assume uboot. Otherwise use none and assume the
+# bootloader (likely grub) is fully bootloader spec capable.
+if [ -f /boot/uEnv.txt ]; then
+    bootloader=uboot
+else
+    bootloader=none
+fi
+
+echo "Setting sysroot.bootloader to $bootloader"
+ostree config set sysroot.bootloader "$bootloader"

--- a/eos-ostree-bootloader-setup.service
+++ b/eos-ostree-bootloader-setup.service
@@ -1,0 +1,25 @@
+[Unit]
+Description=Set OSTree sysroot bootloader configuration
+DefaultDependencies=no
+Conflicts=shutdown.target
+Wants=local-fs.target
+After=local-fs.target
+RequiresMountsFor=/sysroot /boot
+
+# Only run on updates
+Before=multi-user.target systemd-update-done.service
+ConditionNeedsUpdate=|/etc
+ConditionNeedsUpdate=|/var
+
+# Try to run before any ostree applications so that they all see the
+# updated repo configuration.
+Before=eos-autoupdater.service eos-updater.service
+Before=eos-updater-avahi.service eos-update-server.service
+
+[Service]
+Type=oneshot
+RemainAfterExit=true
+ExecStart=/usr/sbin/eos-ostree-bootloader-setup
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
Instead of relying on ostree's automatic bootloader detection, we'd like to specify it since we have to carry an ugly downstream patch to make the automatic detection do what we want. The configuration is simple since the bootloader is either u-boot or grub. In the grub case we want the ostree bootloader configuration to be `none` so that it only updates the bootloader spec entries and doesn't try to manage `grub.cfg`. After a checkpoint we can drop this script and unit.

https://phabricator.endlessm.com/T33364