### PR TITLE
dracut: Compress initrd with zstd

### DIFF
--- a/dracut/endless.conf
+++ b/dracut/endless.conf
@@ -1,3 +1,5 @@
+compress="zstd"
+
 dracutmodules="dracut-systemd systemd-initrd dash drm eos-repartition eos-image-boot plymouth kernel-modules resume ostree systemd base fs-lib eos-customization busybox"
 fscks="fsck fsck.ext4"
 filesystems="isofs"


### PR DESCRIPTION
In our tests, zstd reduces our initrd size by ~25% (16MB) and reduces the decompression time by ~17% (1.5s).

https://phabricator.endlessm.com/T33801