### PR TITLE
Update openh264 extension version

### DIFF
--- a/flatpak-extension-runtime-fdo-openh264-watcher.path.in
+++ b/flatpak-extension-runtime-fdo-openh264-watcher.path.in
@@ -2,7 +2,7 @@
 After=systemd-tmpfiles-setup.service
 
 [Path]
-PathChanged=/var/lib/flatpak/runtime/org.freedesktop.Platform.openh264/@FLATPAK_ARCH@/2.0/active/files/extra/libopenh264.so.6
+PathChanged=/var/lib/flatpak/runtime/org.freedesktop.Platform.openh264/@FLATPAK_ARCH@/2.2.0/active/files/extra/libopenh264.so.6
 
 [Install]
 WantedBy=multi-user.target

--- a/tmpfiles.d/flatpak-extension-runtime-fdo-openh264.conf.in
+++ b/tmpfiles.d/flatpak-extension-runtime-fdo-openh264.conf.in
@@ -1,2 +1,2 @@
 D /run/lib 0755 - - -
-L /run/lib/openh264 - - - - /var/lib/flatpak/runtime/org.freedesktop.Platform.openh264/@FLATPAK_ARCH@/2.0/active/files/extra
+L /run/lib/openh264 - - - - /var/lib/flatpak/runtime/org.freedesktop.Platform.openh264/@FLATPAK_ARCH@/2.2.0/active/files/extra


### PR DESCRIPTION
org.freedesktop.Platform//22.08 introduced this new branch for the 2.2.0 version of OpenH264. We already have the corresponding updates for libnoopenh264 in the OS.

As a bonus, this new version is also available for aarch64.

https://phabricator.endlessm.com/T30986
https://phabricator.endlessm.com/T33476