### PR TITLE
Revert "eos-user-preset: Add user presets to disable pipewire service"

### DIFF
--- a/50-eos-user.preset
+++ b/50-eos-user.preset
@@ -1,5 +1,0 @@
-# Systemd user presets for EOS.
-
-# Disable pipewire service by default - the service can still be activated
-# via socket activation or manually
-disable pipewire.service

--- a/Makefile.am
+++ b/Makefile.am
@@ -9,7 +9,6 @@ AM_DISTCHECK_CONFIGURE_FLAGS = \
 	--with-systemduserunitdir='$${prefix}/lib/systemd/user' \
 	--with-systemdgeneratordir='$${prefix}/lib/systemd/system-generators' \
 	--with-systemdpresetdir='$${prefix}/lib/systemd/system-preset' \
-	--with-systemduserpresetdir='$${prefix}/lib/systemd/user-preset' \
 	--with-udevdir='$${prefix}/lib/udev' \
 	--with-modprobedir='$${prefix}/lib/modprobe.d' \
 	--with-dbussystemconfigdir='$${prefix}/share/dbus-1/system.d' \
@@ -45,10 +44,6 @@ dist_systemdgenerator_SCRIPTS = \
 
 dist_systemdpreset_DATA = \
 	50-eos.preset \
-	$(NULL)
-
-dist_systemduserpreset_DATA = \
-	50-eos-user.preset \
 	$(NULL)
 
 # Network Manager dispatcher script for the firewall - scripts which

--- a/configure.ac
+++ b/configure.ac
@@ -19,9 +19,6 @@ m4_define([no_systemdsystemgeneratordir_error],
 m4_define([no_systemdsystempresetdir_error],
           [m4_normalize([Could not get systemdsystempresetdir setting from]
                         [systemd pkg-config file])])
-m4_define([no_systemduserpresetdir_error],
-          [m4_normalize([Could not get systemduserpresetdir setting from]
-                        [systemd pkg-config file])])
 m4_define([no_udev_error],
           [m4_normalize([Could not get udevdir setting from udev]
                         [pkg-config file])])
@@ -60,13 +57,6 @@ AC_ARG_WITH([systemdpresetdir],
             [PKG_CHECK_VAR([systemdpresetdir], [systemd],
                            [systemdsystempresetdir], [],
                            [AC_MSG_ERROR(no_systemdsystempresetdir_error)])])
-AC_ARG_WITH([systemduserpresetdir],
-            [AS_HELP_STRING([--with-systemduserpresetdir],
-                            [Path to the system directory for systemd user presets])],
-            [systemduserpresetdir="$withval"],
-            [PKG_CHECK_VAR([systemduserpresetdir], [systemd],
-                           [systemduserpresetdir], [],
-                           [AC_MSG_ERROR(no_systemduserpresetdir_error)])])
 AC_ARG_WITH([udevdir],
             [AS_HELP_STRING([--with-udevdir],
                             [Path to the system udev directory])],


### PR DESCRIPTION
This reverts commit 3f7ccdef69a86ccb757dcfdfe1def16fafc9992e.

Pipewire is now the sound server on Endless OS.

https://phabricator.endlessm.com/T34142
