### PR TITLE
Revert "psi-monitor: Drop Pressure Stall Information Monitor"

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,7 @@ depcomp
 fallback-fb-setup/fallback-fb-setup
 install-sh
 missing
+psi-monitor/psi-monitor
 tmpfiles.d/chromium-system-services.conf
 test-driver
 tests/*.log

--- a/Makefile.am
+++ b/Makefile.am
@@ -1,4 +1,4 @@
-SUBDIRS = dracut factory-reset fallback-fb-setup flatpak-repos nvidia record-boot-success tests
+SUBDIRS = dracut factory-reset fallback-fb-setup flatpak-repos nvidia psi-monitor record-boot-success tests
 EXTRA_DIST = debian .flake8
 CLEANFILES =
 

--- a/configure.ac
+++ b/configure.ac
@@ -120,6 +120,7 @@ AC_CONFIG_FILES([
 	fallback-fb-setup/Makefile
 	flatpak-repos/Makefile
 	nvidia/Makefile
+	psi-monitor/Makefile
 	record-boot-success/Makefile
 	tests/Makefile
 	tmpfiles.d/chromium-system-services.conf

--- a/psi-monitor/Makefile.am
+++ b/psi-monitor/Makefile.am
@@ -1,0 +1,6 @@
+sbin_PROGRAMS = psi-monitor
+psi_monitor_SOURCES = psi-monitor.c
+
+dist_systemdunit_DATA = \
+	psi-monitor.service \
+	$(NULL)

--- a/psi-monitor/psi-monitor.c
+++ b/psi-monitor/psi-monitor.c
@@ -1,0 +1,80 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <stdbool.h>
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <fcntl.h>
+#include <err.h>
+#include <unistd.h>
+#include <string.h>
+
+#define DEBUG false
+
+/* Daemon parameters */
+#define POLL_INTERVAL       5
+#define RECOVERY_INTERVAL  15
+#define MEM_THRESHOLD      10
+
+#define SYSRQ_TRIGGER_FILE  "/proc/sysrq-trigger"
+#define PSI_MEMORY_FILE     "/proc/pressure/memory"
+#define BUFSIZE             256
+
+static ssize_t fstr(const char *path, char *rbuf, const char *wbuf) {
+    int fd;
+    ssize_t n;
+
+    /* one and only one operation per call */
+    if ((!rbuf && !wbuf) || (rbuf && wbuf))
+        return 0;
+
+    fd = open(path, rbuf ? O_RDONLY : O_WRONLY);
+    if (fd < 0)
+        err(1, "%s", path);
+
+    if (rbuf)
+        n = read(fd, rbuf, BUFSIZE);
+    else
+        n = write(fd, wbuf, strlen(wbuf));
+    if (n < 0)
+        err(1, "%s", path);
+    close(fd);
+
+    if (rbuf)
+        rbuf[n-1] = '\0';
+
+    return n;
+}
+
+static void sysrq_trigger_oom() {
+    printf("Above threshold limit, killing task and pausing for recovery\n");
+    fstr(SYSRQ_TRIGGER_FILE, NULL, "f");
+    sleep(RECOVERY_INTERVAL);
+}
+
+int main(int argc, char **argv) {
+    setvbuf(stdout, NULL, _IOLBF, 0);
+    printf("poll_interval=%ds, recovery_interval=%ds, stall_threshold=%d%%\n",
+           POLL_INTERVAL, RECOVERY_INTERVAL, MEM_THRESHOLD);
+
+    while (true) {
+        int i;
+        char buf[BUFSIZE];
+        float full_avg10;
+
+        fstr(PSI_MEMORY_FILE, buf, NULL);
+
+        for (i = 0; buf[i] != '\n'; i++);
+        i++; /* skip \n */
+        i+=11; /* skip "full avg10=" */
+
+        sscanf(buf+i, "%f", &full_avg10);
+        if (DEBUG) printf("full_avg10=%f\n", full_avg10);
+
+        if (full_avg10 > MEM_THRESHOLD)
+            sysrq_trigger_oom();
+        else
+            sleep(POLL_INTERVAL);
+    }
+
+    return 0;
+}

--- a/psi-monitor/psi-monitor.service
+++ b/psi-monitor/psi-monitor.service
@@ -1,0 +1,11 @@
+[Unit]
+Description=Pressure Stall Information Monitor
+ConditionPathExists=/proc/pressure
+After=sysinit.target
+
+[Service]
+ExecStart=/usr/sbin/psi-monitor
+Restart=on-failure
+
+[Install]
+WantedBy=basic.target


### PR DESCRIPTION
This reverts commit 356f7bb9f98feec80dbc158c36876661789ca88d.

We had replaced our in-house psi-monitor with low-memory-monitor in enforcing mode, but it has proved too aggressive to work in production, so we are reverting back to psi-monitor for now.

We'll try to understand why low-memory-monitor is behaving differently than psi-monitor despite using the same PSI levels, and hopefully switch back to low-memory-monitor again after some fine-tuning.

https://phabricator.endlessm.com/T34267