### PR TITLE
Update ca certificates after upgrade (eos4.0 backport)

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -29,6 +29,7 @@ dist_systemdunit_DATA = \
 	eos-split-flatpak-repo.service \
 	eos-transient-setup.service \
 	eos-update-flatpak-repos.service \
+	eos-update-system-ca.service \
 	flatpak-extension-runtime-fdo-openh264-ldconfig.service \
 	flatpak-extension-runtime-fdo-openh264-watcher.path \
 	flatpak-extension-runtime-fdo-openh264-watcher.service \

--- a/debian/control
+++ b/debian/control
@@ -25,6 +25,7 @@ Package: eos-boot-helper
 Architecture: any
 Description: Endless boot helper
 Depends: ${misc:Depends},
+         ca-certificates,
          dracut,
          iptables,
          ostree,

--- a/eos-update-system-ca.service
+++ b/eos-update-system-ca.service
@@ -1,0 +1,18 @@
+[Unit]
+Description=Update system CA store
+
+# Only run on updates
+DefaultDependencies=no
+Conflicts=shutdown.target
+Wants=local-fs.target
+After=local-fs.target
+Before=multi-user.target systemd-update-done.service
+ConditionNeedsUpdate=|/etc
+
+[Service]
+Type=oneshot
+RemainAfterExit=true
+ExecStart=/usr/sbin/update-ca-certificates
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
Users, or Endless may add some CAs which do not belong debian packages. Those CAs will be updated into /etc/ssl/certs/ca-certificates.crt and would be likely to be mismatched from the shipped version in /usr/etc.

Add a helper service that runs update-ca-certificates after update and boot to sync up when it is needed.

https://phabricator.endlessm.com/T34308
(cherry picked from commit bb8e30b40a581443da7065cdfcf0804428fc5838)

There was a minor conflict in `Makefile.am` due to 4c9c7f305cf289a858e5387bd6febf222c6fff28 on master/eos5.0.