### PR TITLE
dracut: Disable hostonly to install more modules into initramfs

### DIFF
--- a/dracut/endless.conf
+++ b/dracut/endless.conf
@@ -15,3 +15,8 @@ omit_drivers="nouveau"
 # Ship the bfq IO scheduler module in the initrd, as it's relied upon by
 # our udev rules that detect block devices
 add_drivers+=" bfq "
+
+# The initramfs will be distributed by ostree, so it needs to be generic. If
+# anyone needs to generate a host specific initramfs, they can pass the
+# "--hostonly" option.
+hostonly=no


### PR DESCRIPTION
As an Linux distribution, Endless OS tries to support as much machines as possible. So, install more modules into initramfs generated by dracut to support more storage/block devices during the boot time by disabling "hostonly".

If anyone needs to generate a host specific initramfs, they can pass the "--hostonly" option to dracut.

https://phabricator.endlessm.com/T34575