### PR TITLE
dracut: Omit simpledrm in initramfs

### DIFF
--- a/dracut/endless.conf
+++ b/dracut/endless.conf
@@ -12,6 +12,15 @@ early_microcode="yes"
 # (nouveau cannot be unloaded after it has bound to a device)
 omit_drivers="nouveau"
 
+# Don't include simpledrm in the initramfs to avoid the frame buffer transition
+# on some platforms, like RPi 4B, which blocks system during plymouth splash.
+#
+# We should be able to drop this change with a newer plymouth that includes
+# commit 5dedca81 "ply-device-manager: Also ignore SimpleDRM devs in coldplug
+# enumeration path". See https://phabricator.endlessm.com/T34648 and
+# https://bugzilla.redhat.com/show_bug.cgi?id=2127663.
+omit_drivers+=" simpledrm "
+
 # Ship the bfq IO scheduler module in the initrd, as it's relied upon by
 # our udev rules that detect block devices
 add_drivers+=" bfq "


### PR DESCRIPTION
Don't include simpledrm in the initramfs to avoid the frame buffer transition on some platforms, like RPi 4B, which blocks system during plymouth execution.

https://phabricator.endlessm.com/T34648