### PR TITLE
preset: Disable fwupd-refresh

### DIFF
--- a/50-eos.preset
+++ b/50-eos.preset
@@ -23,6 +23,8 @@ disable eos-update-server.service
 disable eos-update-server.socket
 disable eos-updater-avahi.path
 disable eos-updater-avahi.service
+disable fwupd-refresh.service
+disable fwupd-refresh.timer
 disable ifupdown-wait-online.service
 disable networking.service
 disable NetworkManager-wait-online.service


### PR DESCRIPTION
The service is run periodically with the sole purpose of updating motd. We already have a process that will instruct you about available updates (gnome-software), we really don't care about motd, and it's currently broken since DynamicUser units can't make D-Bus calls on recent systemd[1][2]. Just disable the whole setup.

1. https://github.com/fwupd/fwupd/issues/3037
2. https://github.com/systemd/systemd/issues/22737

https://phabricator.endlessm.com/T31024