### PR TITLE
tmpfiles: Don't create Chromium system extensions symlink

### DIFF
--- a/tmpfiles.d/chromium-system-services.conf.in
+++ b/tmpfiles.d/chromium-system-services.conf.in
@@ -2,6 +2,3 @@ d /etc/chromium-browser 0755 - - -
 d /run/flatpak/extension/org.chromium.Chromium.Policy.system-policies 0755 - - -
 d /run/flatpak/extension/org.chromium.Chromium.Policy.system-policies/@FLATPAK_ARCH@ 0755 - - -
 L /run/flatpak/extension/org.chromium.Chromium.Policy.system-policies/@FLATPAK_ARCH@/1 - - - - /etc/chromium-browser
-d /run/flatpak/extension/org.chromium.Chromium.Extension.system-extensions 0755 - - -
-d /run/flatpak/extension/org.chromium.Chromium.Extension.system-extensions/@FLATPAK_ARCH@ 0755 - - -
-L /run/flatpak/extension/org.chromium.Chromium.Extension.system-extensions/@FLATPAK_ARCH@/1 - - - - /usr/share/chromium


### PR DESCRIPTION
We are removing AdBlock Plus, which is the last thing in
/usr/share/chromium. As a result, that directory will not exist.
If the broken symlink is left in place, bwrap is sad and Chromium fails
to start:

    Apr 18 20:23:04 camille org.chromium.Chromium.flextop.chrome-hnpfjngllnobngcgfapefoaidbinmjnm-Default.desktop[3649]: bwrap: Can't find source path /var/lib/flatpak/extension/org.chromium.Chromium.Extension.system-extensions/x86_64/1: No such file or directory

Remove the tmpfiles rules that add that symlink.

https://phabricator.endlessm.com/T34534
