### PR TITLE
eos-image-boot-setup: use by-uuid symlink for host device identification

### DIFF
--- a/dracut/image-boot/eos-image-boot-setup
+++ b/dracut/image-boot/eos-image-boot-setup
@@ -26,17 +26,14 @@ else
 
   # When booting an ISO using HD emulation (e.g. booting an ISO file flashed
   # to USB), udev records that the ISO UUID applies to both the iso9660
-  # data partition, the parent disk node, and the persistent data storage
-  # partition (if it has not yet been formatted). So we have to be careful
+  # data partition and the parent disk node, so we have to be careful
   # when finding host_device.
-
-  # Let udev finish probing all the partitions
+  #
+  # We wait for udev to finish probing the partitions, and rely on the data
+  # partition node having been probed after the parent device, hence it
+  # will win the race to own the by-uuid symlink.
   udevadm settle
-
-  # To find the data partition, we take advantage of blkid which limits
-  # itself to only searching devices with recognised filesystems that
-  # match the desired UUID.
-  host_device=$(blkid --output device --match-token "${image_device}")
+  host_device=/dev/disk/by-uuid/${image_device#UUID=}
   if ! [ -b "${host_device}" ]; then
     echo "Failed to find host partition device"
     exit 1


### PR DESCRIPTION
It has been a rough ride to accurately translate the endless.image.device=UUID=foo parameter into (e.g.) /dev/sda1, because udev was presenting sda and sda3 (if unformatted) with the same UUID.

We settled on a blkid behaviour that got us the right answer, but it no longer works after upgrading to Debian bookworm. blkid doesn't seem to register UUIDs for any of those devices now.

However, the udev situation has now improved, and an unformatted partition will no longer inherit filesystem info from the parent device: https://github.com/systemd/systemd/issues/14408

This means that we can give the by-uuid symlink approach another shot. Both sda and sda1 will contend for this symlink, but it seems fair to assume that the partition (which we want) will always be probed after the parent device.

https://phabricator.endlessm.com/T35109