### PR TITLE
nvidia: Set NVreg_PreserveVideoMemoryAllocations

### DIFF
--- a/nvidia/nvidia-graphics-setup
+++ b/nvidia/nvidia-graphics-setup
@@ -190,7 +190,7 @@ if ! modprobe -c | grep -F -x --quiet "blacklist nvidia" &&
 
   build_nvidia_if_needed
   echo "Loading nvidia modules"
-  load_module "${MODULE_DIR}"/nvidia.ko
+  load_module "${MODULE_DIR}"/nvidia.ko NVreg_PreserveVideoMemoryAllocations=1
   load_module "${MODULE_DIR}"/nvidia-modeset.ko
   load_module "${MODULE_DIR}"/nvidia-drm.ko modeset=1
   first_boot_cleanup_modules


### PR DESCRIPTION
Set NVreg_PreserveVideoMemoryAllocations to enable Wayland for hybrid NVIDIA GPU with gdm 43(+).

https://phabricator.endlessm.com/T35012