### PR TITLE
T35041 add user manager config

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -56,6 +56,10 @@ dist_systemdsystemmanagerconf_DATA = \
 	10-eos-oom-policy.conf \
 	$(NULL)
 
+dist_systemdusermanagerconf_DATA = \
+	10-eos-oom-policy.conf \
+	$(NULL)
+
 # Network Manager dispatcher script for the firewall - scripts which
 # are a symlink to no-wait.d will be run without blocking/ordering.
 # install the script here and make the symlink in install-data-hook

--- a/configure.ac
+++ b/configure.ac
@@ -82,6 +82,11 @@ AC_ARG_WITH([systemdsystemmanagerconfdir],
                             [Path to the system directory for systemd system service manager configuration])],
             [systemdsystemmanagerconfdir="$withval"], [systemdsystemmanagerconfdir="$systemdutildir/system.conf.d"])
 AC_SUBST(systemdsystemmanagerconfdir)
+AC_ARG_WITH([systemdusermanagerconfdir],
+            [AS_HELP_STRING([--with-systemdusermanagerconfdir],
+                            [Path to the system directory for systemd user service manager configuration])],
+            [systemdusermanagerconfdir="$withval"], [systemdusermanagerconfdir="$systemdutildir/user.conf.d"])
+AC_SUBST(systemdusermanagerconfdir)
 AC_ARG_WITH([udevdir],
             [AS_HELP_STRING([--with-udevdir],
                             [Path to the system udev directory])],


### PR DESCRIPTION
To achieve this, we will copy the same configuration file that is added
to system.conf.d.

This change is necessary to prevent systemd from stopping the user
session when a child process is killed by the OOM killer. It should be
possible to revert this once Endless OS is using systemd >= v253, where
OOMPolicy defaults to "continue" for login session scopes:
https://github.com/systemd/systemd/commit/98b6c94b577205d31b019286c2a84cc9af244ea0

https://phabricator.endlessm.com/T35041