### PR TITLE
repartition: Ensure blkid is installed

### DIFF
--- a/dracut/repartition/module-setup.sh
+++ b/dracut/repartition/module-setup.sh
@@ -17,6 +17,7 @@ install() {
   dracut_install sed
   dracut_install tune2fs
   dracut_install iconv
+  dracut_install blkid
   dracut_install -o amlogic-fix-spl-checksum
   inst_script "$moddir/endless-repartition.sh" /bin/endless-repartition
   inst_simple "$moddir/endless-repartition.service" \


### PR DESCRIPTION
`blkid` is used to determine the partition type during repartitioning, but the module wasn't ensuring it was being installed.

https://phabricator.endlessm.com/T35134