### PR TITLE
Add suspend-mode-setup to force system use preferred suspend mode

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -1,4 +1,4 @@
-SUBDIRS = dracut factory-reset fallback-fb-setup flatpak-repos nvidia psi-monitor record-boot-success tests
+SUBDIRS = dracut factory-reset fallback-fb-setup flatpak-repos nvidia psi-monitor record-boot-success suspend-mode-setup tests
 EXTRA_DIST = debian .flake8
 CLEANFILES =
 

--- a/configure.ac
+++ b/configure.ac
@@ -142,6 +142,7 @@ AC_CONFIG_FILES([
 	nvidia/Makefile
 	psi-monitor/Makefile
 	record-boot-success/Makefile
+	suspend-mode-setup/Makefile
 	tests/Makefile
 	tmpfiles.d/chromium-system-services.conf
 ])

--- a/suspend-mode-setup/Makefile.am
+++ b/suspend-mode-setup/Makefile.am
@@ -1,0 +1,7 @@
+dist_systemdunit_DATA = \
+	suspend-mode-setup.service \
+	$(NULL)
+
+dist_sbin_SCRIPTS = \
+	suspend-mode-setup \
+	$(NULL)

--- a/suspend-mode-setup/suspend-mode-setup
+++ b/suspend-mode-setup/suspend-mode-setup
@@ -1,0 +1,26 @@
+#!/bin/bash
+
+# Here is a model list which is going to use s2idle mode for suspend. The items
+# is a composite string by System Vendor and Product Name. Here uses Mission One
+# as an example to get the information from system's DMI information:
+#
+# $ cat /sys/class/dmi/id/sys_vendor
+# GIGABYTE
+# $ cat /sys/class/dmi/id/product_name
+# Mission one
+#
+# Form them as a string "GIGABYTE Mission one" and append it into
+# s2idle_model_list.
+
+s2idle_model_list=("GIGABYTE Mission one")
+
+SYS_VENDOR=`cat /sys/class/dmi/id/sys_vendor`
+PRODUCT_NAME=`cat /sys/class/dmi/id/product_name`
+MODEL_FULLNAME="${SYS_VENDOR} ${PRODUCT_NAME}"
+
+for model in "${s2idle_model_list[@]}"; do
+	if [ "${model}" == "${MODEL_FULLNAME}" ]; then
+		echo "Force ${MODEL_FULLNAME} use s2idle mode for suspend"
+		echo s2idle > /sys/power/mem_sleep
+	fi
+done

--- a/suspend-mode-setup/suspend-mode-setup.service
+++ b/suspend-mode-setup/suspend-mode-setup.service
@@ -1,0 +1,10 @@
+[Unit]
+Description=Suspend Mode Setup According to Model List
+Before=NetworkManager.service
+
+[Service]
+Type=oneshot
+ExecStart=/usr/sbin/suspend-mode-setup
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
Add suspend-mode-setup.service executing suspend-mode-setup when system boots up. It forces system use preferred suspend mode. For example, GIGABYTE Mission One should use s2idle.

Since Mission One is the only one in the list, put it into the array s2idle_model_list in suspend-mode-setup script directly now. It can be split into another data file, if there are more models in the future.

https://phabricator.endlessm.com/T35070#988997