### PR TITLE
udev: Force Mission one use s2idle suspend mode

### DIFF
--- a/60-suspend-mode.rules
+++ b/60-suspend-mode.rules
@@ -1,0 +1,2 @@
+SUBSYSTEM=="dmi", ENV{ID_VENDOR}="GIGABYTE", ENV{ID_MODEL}="Mission one", RUN{program}+="/bin/sh -c 'echo s2idle > /sys/power/mem_sleep'"
+SUBSYSTEM=="dmi", ENV{ID_MODEL}="GB-BXBT-2807", RUN{program}+="/bin/sh -c 'echo s2idle > /sys/power/mem_sleep'"

--- a/Makefile.am
+++ b/Makefile.am
@@ -86,6 +86,7 @@ dist_udevrules_DATA = \
 	50-disk-bfq.rules \
 	50-meson-vdec.rules \
 	50-usb-mouse-wakeup.rules \
+	60-suspend-mode.rules \
 	$(NULL)
 
 polkitrulesdir = $(datadir)/polkit-1/rules.d


### PR DESCRIPTION
Mission one cannot resume from S3 suspend by any key press, nor other outside trigger ways. Because the USB is dead. Use s2idle mode to avoid turn off USB when suspend.

https://phabricator.endlessm.com/T35070