### PR TITLE
udev: Use "==" for comparing, not "=" in the rules

### DIFF
--- a/60-suspend-mode.rules
+++ b/60-suspend-mode.rules
@@ -1,2 +1,2 @@
-SUBSYSTEM=="dmi", ENV{ID_VENDOR}="GIGABYTE", ENV{ID_MODEL}="Mission one", RUN{program}+="/bin/sh -c 'echo s2idle > /sys/power/mem_sleep'"
-SUBSYSTEM=="dmi", ENV{ID_MODEL}="GB-BXBT-2807", RUN{program}+="/bin/sh -c 'echo s2idle > /sys/power/mem_sleep'"
+SUBSYSTEM=="dmi", ENV{ID_VENDOR}=="GIGABYTE", ENV{ID_MODEL}=="Mission one", RUN{program}+="/bin/sh -c 'echo s2idle > /sys/power/mem_sleep'"
+SUBSYSTEM=="dmi", ENV{ID_MODEL}=="GB-BXBT-2807", RUN{program}+="/bin/sh -c 'echo s2idle > /sys/power/mem_sleep'"


### PR DESCRIPTION
This fixes commit 6f25d79309d2 ("udev: Force Mission one use s2idle suspend mode") to match DMI correctly.

https://phabricator.endlessm.com/T35246