### PR TITLE
Disable dpkg-db-backup.timer and systemd-sysupdate.timer

### DIFF
--- a/50-eos.preset
+++ b/50-eos.preset
@@ -6,6 +6,8 @@
 disable systemd-networkd.service
 disable systemd-resolved.service
 disable systemd-networkd-wait-online.service
+disable systemd-sysupdate.timer
+disable systemd-sysupdate-reboot.timer
 
 # Disable other unwanted units
 disable apt-daily.timer

--- a/50-eos.preset
+++ b/50-eos.preset
@@ -16,6 +16,7 @@ disable cni-dhcp.service
 disable crio.service
 disable crio-shutdown.service
 disable cron.service
+disable dpkg-db-backup.timer
 disable eos-factory-reset-users.service
 disable eos-firewall-localonly.service
 disable eos-safe-defaults.service


### PR DESCRIPTION
* disable dpkg-db-backup.timer to avoid triggering dpkg-db-backup.service automatically.
* disable systemd-sysupdate.timer to avoid triggering systemd-sysupdate.service automatically.

https://phabricator.endlessm.com/T35292