### PR TITLE
eos-user-preset: Drop disable pipewire service

### DIFF
--- a/50-eos-user.preset
+++ b/50-eos-user.preset
@@ -1,5 +1,1 @@
 # Systemd user presets for EOS.
-
-# Disable pipewire service by default - the service can still be activated
-# via socket activation or manually
-disable pipewire.service


### PR DESCRIPTION
EOS uses pipewire now. And, "pipewire.service" will be triggered by the socket per user session automatically.

pipewire.service - PipeWire Multimedia Service
     Loaded: loaded (/usr/lib/systemd/user/pipewire.service; disabled; preset: disabled)
     Active: active (running) since Wed 2024-04-03 16:03:17 CST; 1h 39min ago
TriggeredBy: ● pipewire.socket
   Main PID: 1471 (pipewire)
      Tasks: 3 (limit: 4378)
     Memory: 5.9M
        CPU: 2.458s
     CGroup: /user.slice/user-1000.slice/user@1000.service/session.slice/pipewire.service
             └─1471 /usr/bin/pipewire

Apr 03 16:03:17 endless systemd[1439]: Started pipewire.service - PipeWire Multimedia Service.
Apr 03 16:03:17 endless pipewire[1471]: mod.jackdbus-detect: Failed to receive jackdbus reply: org.freedesktop.DBus.Error.ServiceUnknown: The name org.jackaudio.service was not provided by any .service files

So, there is no reason preset pipewire.service as disabled.

https://phabricator.endlessm.com/T35294