### PR TITLE
image-boot: fix read-only block device handling

### DIFF
--- a/dracut/image-boot/eos-image-boot-setup
+++ b/dracut/image-boot/eos-image-boot-setup
@@ -9,7 +9,7 @@ if [ $# -ge 1 ]; then
   # For testing
   if [ "$1" = "--readonly" ]; then
     shift
-    disk_ro=1
+    roflag="-r"
   fi
 
   host_device="$1"
@@ -38,10 +38,8 @@ else
   # If possible, create partition for persistent data storage
   eos-live-storage-setup "${host_device}"
 
-  getargbool 0 endless.live_boot && disk_ro=1
+  getargbool 0 endless.live_boot && roflag="-r"
 fi
-
-[ -n "${disk_ro}" ] && blockdev --setro ${host_device}
 
 fstype=$(lsblk --noheadings -o FSTYPE "${host_device}")
 if [ $? != 0 ]; then
@@ -78,7 +76,7 @@ fi
 
 # Create a loopback device backing the image
 image_device=$(losetup -f)
-losetup ${image_device} /outer_image/${image_path}
+losetup ${roflag} ${image_device} /outer_image/${image_path}
 if [ $? != 0 ]; then
   echo "losetup failed for /outer_image/${image_path}"
   exit 1

--- a/tests/test_image_boot.py
+++ b/tests/test_image_boot.py
@@ -130,7 +130,6 @@ class TestImageBootSetup(ImageTestCase):
                 '--associated', image,
             ))
             subprocess.call(('losetup', '--detach', dev.strip()))
-            subprocess.call(('blockdev', '--setrw', dev.strip()))
 
     def _go(self, host_device, image_path, readonly=False):
         mapped_dev = '/dev/disk/endless-image'
@@ -154,7 +153,6 @@ class TestImageBootSetup(ImageTestCase):
             # details of eos-image-boot-setup, whose effects are not really
             # intended to be undone -- in normal use, the mapped OS image and
             # everything behind it must exist until the machine is shut down.
-            subprocess.call(('blockdev', '--setrw', host_device))
             subprocess.call(('partx', '-d', '-v', mapped_dev))
 
             self._detach_if_exists('/squash/endless.img')


### PR DESCRIPTION
The `blockdev --setro` invocation here was too broad, because in cases of live booting with persistent storage enabled, we will need to write to persistent.img on the host device.

You might think the next place down the stack where we could start the read-only setting would be at the outer image mount, however, that is again mounting the host device, and the kernel later refuses to create a read-write mount (for persistent.img access) if the original mount is read-only.

Leave the real partition node as read-write, and instead start the read-only setting at the first loopback device. (All further loop devices and mounts created within will have the read-only flag propagated.)

https://phabricator.endlessm.com/T35126