### PR TITLE
psi-monitor: Raise default memory pressure threshold to 30%

### DIFF
--- a/psi-monitor/psi-monitor.c
+++ b/psi-monitor/psi-monitor.c
@@ -15,9 +15,14 @@
 /* Daemon parameters */
 static unsigned int poll_interval = 5;
 static unsigned int recovery_interval = 15;
-static unsigned int mem_threshold = 10;
+static unsigned int mem_threshold = 30;
 
 #define SYSRQ_TRIGGER_FILE  "/proc/sysrq-trigger"
+/*
+ * "/proc/pressure/memory" is memory pressure interface provided by kernel.
+ * Please refer to PSI - Pressure Stall Information for more detail:
+ * https://docs.kernel.org/accounting/psi.html
+ */
 #define PSI_MEMORY_FILE     "/proc/pressure/memory"
 #define BUFSIZE             256
 


### PR DESCRIPTION
Current PSI monitor's default memory pressure threshold is 10%. However, according to the application usage, the memory pressure (full avg10) exceeds the threshold 10% easily, then PSI monitor triggers OOM killer to kill a process for taking memory back. But, there is still some available memory space at the moment. That means it is too sensitive on some users' side.

Thanks to the statistics of application usage and the memory pressure measured by Daniel. This commit raises the memory pressure threshold to 30% for trying more widely. Hope it get to the balance more closely.

Besides, add a comment about the memory pressure interface provided by kernel.

https://phabricator.endlessm.com/T35318