### PR TITLE
overlay-setup: Ensure units ordered after /var overlay

### DIFF
--- a/eos-live-boot-overlayfs-setup
+++ b/eos-live-boot-overlayfs-setup
@@ -106,6 +106,19 @@ setup_overlay() {
         "eos-live-$dir" "/$dir"
 }
 
+# This service is ordered before var.mount so that any units that only
+# depend on /var without being ordered after local-fs.target will not be
+# started until the /var overlay is in place. As such, this service
+# needs to take over the var.mount created by ostree-system-generator.
+echo "Bind mounting /sysroot/ostree/deploy/eos/var to /var"
+mount --bind /sysroot/ostree/deploy/eos/var /var
+
+# Mark the /sysroot mount as private so that the /var overlay mount
+# isn't mirrored into it. Normally this is done by ostree-remount, but
+# we're ordered before it.
+echo "Marking /sysroot mount as private"
+mount --make-rprivate /sysroot
+
 # Prior to EOS 4 the system flatpak repo was a symlink to the system
 # ostree repo to allow flatpak and OS commits to share objects. The
 # repos have been split now, but an updated system may not have been

--- a/eos-live-boot-overlayfs-setup.service
+++ b/eos-live-boot-overlayfs-setup.service
@@ -1,30 +1,22 @@
 [Unit]
 Description=Endless live boot overlayfs setup
 DefaultDependencies=no
-After=ostree-remount.service var.mount
-Before=local-fs.target
 ConditionKernelCommandLine=endless.live_boot
 
-# Systemd ships several units that require access to /var but are not ordered
-# after local-fs.target. It would be better if they did, but that's not the
-# case today. Systemd doesn't expect the kind of mount post-processing that's
-# done here.
-#
-# You can find these with the following command:
-#
-# grep -rl -e StateDirectory -e CacheDirectory -e LogsDirectory -e var.mount \
-#   -e 'RequiresMountsFor=.*/var' /usr/lib/systemd/system \
-#   | xargs grep -l -e DefaultDependencies | sort
-Before=systemd-backlight@.service
-Before=systemd-coredump@.service
-Before=systemd-journal-flush.service
-Before=systemd-pstore.service
-Before=systemd-random-seed.service
-Before=systemd-rfkill.service
-Before=systemd-rfkill.socket
-Before=systemd-timesyncd.service
-Before=systemd-update-utmp-runlevel.service
-Before=systemd-update-utmp.service
+# systemd-remount-fs.service is masked by the live boot generator, but
+# make sure to run after it.
+After=systemd-remount-fs.service
+
+# ostree-remount.service is ordered after var.mount, so this service
+# expects to run before it. Order it explicitly to make sure.
+Before=ostree-remount.service
+
+# Make sure the overlay setup is complete before services that need real
+# filesystems are started. Normally local-fs.target would be good
+# enough, but systemd optimizes some units to only wait for /var rather
+# than all local filesystems. Note that ordering before var.mount means
+# this service has to handle the /var mount itself.
+Before=local-fs.target var.mount
 
 [Service]
 Type=oneshot
@@ -32,4 +24,4 @@ ExecStart=/usr/sbin/eos-live-boot-overlayfs-setup
 RemainAfterExit=yes
 
 [Install]
-WantedBy=local-fs.target
+WantedBy=local-fs.target var.mount


### PR DESCRIPTION
Trying to create a list of units that require /var as in 0cddd9e is a losing game. It also doesn't really work properly since you can't order against all instances of a templated unit like foo@.service.

As suggested by upstream[1], the more robust way to handle this is to order the service before var.mount. That requires handling the /var mount in the service, but fortunately that's straightforward for this narrow use case.

With that change, the service will also run before ostree-remount.service, which means it has to take care of marking the /sysroot mount as private. Without that, the /var overlay mount will be mirrored under /sysroot.

1. https://github.com/systemd/systemd/issues/32343

https://phabricator.endlessm.com/T35323