### PR TITLE
psi-monitor: Raise default memory pressure kill threshold to 40% for EOS 5.1

### DIFF
--- a/psi-monitor/Makefile.am
+++ b/psi-monitor/Makefile.am
@@ -1,3 +1,5 @@
+AM_CFLAGS = -Wall -Werror
+
 sbin_PROGRAMS = psi-monitor
 psi_monitor_SOURCES = psi-monitor.c
 

--- a/psi-monitor/psi-monitor.c
+++ b/psi-monitor/psi-monitor.c
@@ -9,8 +9,6 @@
 #include <string.h>
 #include <getopt.h>
 
-#define DEBUG false
-
 /* Daemon parameters */
 #define POLL_INTERVAL       5
 #define RECOVERY_INTERVAL  15
@@ -20,8 +18,10 @@
 #define PSI_MEMORY_FILE     "/proc/pressure/memory"
 #define BUFSIZE             256
 
-static const char *short_options = "h";
+static bool opt_debug = false;
+static const char *short_options = "dh";
 static struct option long_options[] = {
+    {"debug", 0, 0, 'd'},
     {"help", 0, 0, 'h'},
     {0, 0, 0, 0}
 };
@@ -30,6 +30,7 @@ static void usage(const char *progname) {
     printf("Usage: %s [OPTION]...\n"
            "Invoke out of memory killer on excessive memory pressure.\n"
            "\n"
+           "  -d, --debug\tprint debugging messages\n"
            "  -h, --help\tdisplay this help and exit\n",
            progname);
 }
@@ -73,6 +74,9 @@ int main(int argc, char **argv) {
             break;
 
         switch (c) {
+        case 'd':
+            opt_debug = true;
+            break;
         case 'h':
             usage(argv[0]);
             return 0;
@@ -97,7 +101,7 @@ int main(int argc, char **argv) {
         i+=11; /* skip "full avg10=" */
 
         sscanf(buf+i, "%f", &full_avg10);
-        if (DEBUG) printf("full_avg10=%f\n", full_avg10);
+        if (opt_debug) printf("full_avg10=%f\n", full_avg10);
 
         if (full_avg10 > MEM_THRESHOLD)
             sysrq_trigger_oom();

--- a/psi-monitor/psi-monitor.c
+++ b/psi-monitor/psi-monitor.c
@@ -62,7 +62,6 @@ static ssize_t fstr(const char *path, char *rbuf, const char *wbuf) {
 }
 
 static void sysrq_trigger_oom() {
-    printf("Above threshold limit, killing task and pausing for recovery\n");
     fstr(SYSRQ_TRIGGER_FILE, NULL, "f");
     sleep(RECOVERY_INTERVAL);
 }
@@ -103,10 +102,14 @@ int main(int argc, char **argv) {
         sscanf(buf+i, "%f", &full_avg10);
         if (opt_debug) printf("full_avg10=%f\n", full_avg10);
 
-        if (full_avg10 > MEM_THRESHOLD)
+        if (full_avg10 > MEM_THRESHOLD) {
+            printf("Memory pressure %.1f%% above threshold limit %d%%, "
+                   "killing task and pausing %d seconds for recovery\n",
+                   full_avg10, MEM_THRESHOLD, RECOVERY_INTERVAL);
             sysrq_trigger_oom();
-        else
+        } else {
             sleep(POLL_INTERVAL);
+        }
     }
 
     return 0;

--- a/psi-monitor/psi-monitor.c
+++ b/psi-monitor/psi-monitor.c
@@ -7,6 +7,7 @@
 #include <err.h>
 #include <unistd.h>
 #include <string.h>
+#include <getopt.h>
 
 #define DEBUG false
 
@@ -18,6 +19,20 @@
 #define SYSRQ_TRIGGER_FILE  "/proc/sysrq-trigger"
 #define PSI_MEMORY_FILE     "/proc/pressure/memory"
 #define BUFSIZE             256
+
+static const char *short_options = "h";
+static struct option long_options[] = {
+    {"help", 0, 0, 'h'},
+    {0, 0, 0, 0}
+};
+
+static void usage(const char *progname) {
+    printf("Usage: %s [OPTION]...\n"
+           "Invoke out of memory killer on excessive memory pressure.\n"
+           "\n"
+           "  -h, --help\tdisplay this help and exit\n",
+           progname);
+}
 
 static ssize_t fstr(const char *path, char *rbuf, const char *wbuf) {
     int fd;
@@ -52,6 +67,20 @@ static void sysrq_trigger_oom() {
 }
 
 int main(int argc, char **argv) {
+    while (true) {
+        int c = getopt_long(argc, argv, short_options, long_options, NULL);
+        if (c == -1)
+            break;
+
+        switch (c) {
+        case 'h':
+            usage(argv[0]);
+            return 0;
+        default:
+            return 1;
+        }
+    }
+
     setvbuf(stdout, NULL, _IOLBF, 0);
     printf("poll_interval=%ds, recovery_interval=%ds, stall_threshold=%d%%\n",
            POLL_INTERVAL, RECOVERY_INTERVAL, MEM_THRESHOLD);

--- a/psi-monitor/psi-monitor.c
+++ b/psi-monitor/psi-monitor.c
@@ -15,7 +15,7 @@
 /* Daemon parameters */
 static unsigned int poll_interval = 5;
 static unsigned int recovery_interval = 15;
-static unsigned int mem_threshold = 30;
+static unsigned int mem_threshold = 40;
 
 #define SYSRQ_TRIGGER_FILE  "/proc/sysrq-trigger"
 /*

--- a/psi-monitor/psi-monitor.c
+++ b/psi-monitor/psi-monitor.c
@@ -15,9 +15,14 @@
 /* Daemon parameters */
 static unsigned int poll_interval = 5;
 static unsigned int recovery_interval = 15;
-static unsigned int mem_threshold = 10;
+static unsigned int mem_threshold = 30;
 
 #define SYSRQ_TRIGGER_FILE  "/proc/sysrq-trigger"
+/*
+ * "/proc/pressure/memory" is memory pressure interface provided by kernel.
+ * Please refer to PSI - Pressure Stall Information for more detail:
+ * https://docs.kernel.org/accounting/psi.html
+ */
 #define PSI_MEMORY_FILE     "/proc/pressure/memory"
 #define BUFSIZE             256
 


### PR DESCRIPTION
Backport raising PSI monitor's default memory pressure threshold to 40% to EOS 5.1.

https://phabricator.endlessm.com/T35318