### PR TITLE
Run eos-firstboot a second time on dual-boot systems

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -25,6 +25,7 @@ dist_systemdunit_DATA = \
 	eos-live-boot-overlayfs-setup.service \
 	eos-ostree-bootloader-setup.service \
 	eos-prune-printers.service \
+	eos-retrigger-firstboot.service \
 	eos-transient-setup.service \
 	eos-update-flatpak-repos.service \
 	eos-update-system-ca.service \

--- a/eos-retrigger-firstboot.service
+++ b/eos-retrigger-firstboot.service
@@ -1,0 +1,19 @@
+# On dual-boot systems, (re)run eos-firstboot to grow the root filesystem, which
+# was not grown correctly on first boot into Endless OS 6.0.0.
+[Unit]
+Description=Fix dual-boot filesystem size
+DefaultDependencies=no
+After=sysinit.target local-fs.target
+Before=basic.target eos-firstboot.service
+ConditionPathExists=!/var/%N
+ConditionKernelCommandLine=endless.image.device
+ConditionKernelCommandLine=!endless.live_boot
+
+[Service]
+Type=oneshot
+ExecStart=rm -f /var/eos-booted
+ExecStartPost=touch /var/%N
+StandardOutput=journal+console
+
+[Install]
+WantedBy=basic.target


### PR DESCRIPTION
In new dual-boot installs of 6.0.0, eos-firstboot did not correctly grow the filesystem due to the bug fixed in commit
56aea35e497df9d035e8ccf391d9b720de264530.

We now want to run it a second time, only on dual-boot systems. Ideally we would like to only trigger this on dual-boot systems that were affected by this bug but it's harder to detect that case than to run eos-firstboot again and have resize2fs gracefully do nothing.

When booting a non-live image-booted system which has not previously run this unit, remove the flag file (if present) that prevents eos-firstboot.service from running more than once, then touch another flag file to prevent running this unit again. The service is ordered Before=eos-firstboot.service and is Type=oneshot so we are guaranteed that its ExecStart= line has completed before eos-firstboot.service's ConditionPathExists check is evaluated. From systemd.unit(5):

> The conditions and asserts are checked at the time the queued start
> job is to be executed. The ordering dependencies are still respected,
> so other units are still pulled in and ordered as if this unit was
> successfully activated, and the conditions and asserts are executed
> the precise moment the unit would normally start and thus can validate
> system state after the units ordered before completed initialization.

On a fresh installation of an image containing this unit, /var/eos-booted does not exist; so this unit has no effect but is harmless.

On a system originally installed with 6.0.0, eos-firstboot.service will be retriggered once and will successfully resize the filesystem to fill the partition.

On a system originally installed with a release prior to 6.0.0, eos-firstboot.service will be retriggered once and will successfully take no action.

https://phabricator.endlessm.com/T35432