### PR TITLE
Run eos-firstboot a second time on existing installs

### DIFF
--- a/eos-firstboot
+++ b/eos-firstboot
@@ -6,5 +6,5 @@ root_part=$(findmnt -rvnf -o SOURCE /)
 
 resize2fs "${root_part}"
 
-> /var/eos-booted
+> /var/lib/eos-firstboot
 exit 0

--- a/eos-firstboot.service
+++ b/eos-firstboot.service
@@ -5,11 +5,12 @@ Description=Endless Boot Helper
 DefaultDependencies=no
 After=sysinit.target local-fs.target
 Before=basic.target
-ConditionPathExists=!/var/eos-booted
+ConditionPathExists=!/var/lib/%N
 ConditionKernelCommandLine=!endless.live_boot
 
 [Service]
 ExecStart=/usr/sbin/eos-firstboot
+ExecStartPost=-rm -f /var/eos-booted
 StandardOutput=journal+console
 
 [Install]


### PR DESCRIPTION
An alternative approach to https://github.com/endlessm/eos-boot-helper/pull/408.

----

In new dual-boot installs of 6.0.0, eos-firstboot did not correctly grow the filesystem due to the bug fixed in commit
56aea35e497df9d035e8ccf391d9b720de264530.

We now want to run it a second time. Ideally we would only trigger it on affected dual-boot systems; but it is harder to detect that case than to run eos-firstboot again and have resize2fs gracefully do nothing.

While we could easily run a unit only on dual-boot systems with:

    ConditionKernelCommandLine=endless.image.device
    ConditionKernelCommandLine=!endless.live_boot

to do this only once requires a second unit with its own new flag file. So rather than introducing a second flag file, let's harmlessly re-run this unit once on all systems, and take the opportunity to move the flag file out of the top-level of /var to /var/lib/eos-firstboot.

https://phabricator.endlessm.com/T35432