### PR TITLE
repartition: Use partx rather than busybox partprobe

### DIFF
--- a/dracut/repartition/endless-repartition.sh
+++ b/dracut/repartition/endless-repartition.sh
@@ -201,7 +201,7 @@ udevadm settle
 
 # Loop devices need a prod
 if [ -n "$using_loop" ]; then
-  partprobe $root_disk
+  partx --update --verbose $root_disk
   udevadm settle
 fi
 

--- a/dracut/repartition/module-setup.sh
+++ b/dracut/repartition/module-setup.sh
@@ -17,6 +17,7 @@ install() {
   dracut_install tune2fs
   dracut_install iconv
   dracut_install blkid
+  dracut_install partx
   inst_script "$moddir/endless-repartition.sh" /bin/endless-repartition
   inst_simple "$moddir/endless-repartition.service" \
 	"$systemdsystemunitdir/endless-repartition.service"


### PR DESCRIPTION
Since da7b937b252bfe5776d3d6ef8902d8fd93453bfd, partprobe in the
initramfs is busybox, not the tool from parted.

For unknown reasons, busybox partprobe fails to probe /dev/loop0 after
it has been repartitioned, failing with:

    partprobe: /dev/loop0: Invalid argument

partx --update performs a similar function, except that it works
correctly at this stage of the boot process. Using partx also has the
advantage that running this tool manually from the booted system (where
partprobe is the real thing) will actually run the same code as in the
initramfs.

https://phabricator.endlessm.com/T35432
