### PR TITLE
Revert "eos-test-mode: Remount eos-live overlays in some services' namespace"

### DIFF
--- a/eos-test-mode
+++ b/eos-test-mode
@@ -28,15 +28,3 @@ systemctl mask --runtime --now eos-autoupdater.timer eos-autoupdater.service
 
 # Disable phoning home for this boot, too
 systemctl mask --runtime --now eos-phone-home.{service,timer,path}
-
-# Restart systemd services which mount real storage blocks to the paths under
-# /sysroot/ directly. This helps them remount the eos-live overlays in their
-# namespace. This is caused by ostree making the /sysroot mount private.
-# https://phabricator.endlessm.com/T35625
-pattern='$1 ~ "^/dev/" && $2 ~ "^/sysroot/"'
-action='{split(FILENAME, p, "/"); print p[3]; nextfile}'
-awk "$pattern $action" /proc/*/mounts | uniq | while read -r pid;
-do
-	service=$(systemctl whoami $pid)
-	systemctl restart $service
-done


### PR DESCRIPTION
This reverts commit 28e58e8f7a8c0e83de079014915dbbcca7cdec30.

The underlying bug in ostree was fixed in
https://github.com/endlessm/ostree/pull/214, a backport of https://github.com/ostreedev/ostree/pull/3292.

With that change, eos-test-mode's overmounted overlayfses propagate correctly to NetworkManager and AccountsService, so they no longer need to be restarted. And restarting NetworkManager triggers a bug in Initial Setup, which does not correctly handle this case and so never lists available Wi-Fi networks.

https://phabricator.endlessm.com/T35640