### PR TITLE
Partially revert "Remove obsolete cleanup of obsolete stamp files"

### DIFF
--- a/tmpfiles.d/eos-boot-helper.conf
+++ b/tmpfiles.d/eos-boot-helper.conf
@@ -3,3 +3,7 @@ r /var/lib/eos4-prune-printers
 
 # Remove stamp file from eos-reclaim-swap (itself removed in Endless OS 4)
 r /var/eos-swap-reclaimed
+
+# remove stamp file from eos-fix-home-dir-permissions
+# (from 3.1.6 change to default home dir permissions)
+r /var/lib/misc/eos-dir-mode-700


### PR DESCRIPTION
This reverts part of commit 1338aae7721a5bfddc8b121fb1b761bd779d4313.

Sadly I had not realised that this stamp file was also created by a hook in the image builder. So on every new system installed between 3.5.0 and 6.0.1 inclusive, this stamp file was preinstalled and deleted on first boot; while on all systems installed with 6.0.2 or newer, the stamp file was preinstalled but never removed.

https://github.com/endlessm/eos-image-builder/pull/173 removes the image builder hook, but for the sake of those systems installed with 6.0.2 or newer, reinstate the tmpfiles snippet that deletes the stamp file.

