### PR TITLE
eos-enable-zram: Enable swap discards

### DIFF
--- a/eos-enable-zram
+++ b/eos-enable-zram
@@ -19,7 +19,7 @@ if [ "$1" -ne 0 ]; then
     # For now, disable the swap partition if in use
     swapoff -a
     mkswap /dev/zram0
-    swapon /dev/zram0
+    swapon -d /dev/zram0
 else
     swapoff /dev/zram0
     echo 1 > /sys/block/zram0/reset


### PR DESCRIPTION
Over prolonged periods, memory allocated to backing zram devices starts to consume more memory, even when pages are unswapped, resulting in increased swappiness and the machine slowing down. Enable discards in the swap layer, so that the backing zram pages can be freed, allowing more hot pages to stay uncompressed.