### PR TITLE
Move EOS systemd downstream configs to eos-boot-helper

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -1,4 +1,4 @@
-SUBDIRS = dracut factory-reset fallback-fb-setup flatpak-repos nvidia psi-monitor record-boot-success . tests
+SUBDIRS = dracut factory-reset fallback-fb-setup flatpak-repos journald nvidia psi-monitor record-boot-success . tests
 EXTRA_DIST = debian .flake8 pytest.ini
 CLEANFILES =
 

--- a/Makefile.am
+++ b/Makefile.am
@@ -1,4 +1,4 @@
-SUBDIRS = dracut factory-reset fallback-fb-setup flatpak-repos journald nvidia psi-monitor record-boot-success . tests
+SUBDIRS = dracut factory-reset fallback-fb-setup flatpak-repos journald locale nvidia psi-monitor record-boot-success . tests
 EXTRA_DIST = debian .flake8 pytest.ini
 CLEANFILES =
 

--- a/configure.ac
+++ b/configure.ac
@@ -131,6 +131,7 @@ AC_CONFIG_FILES([
 	factory-reset/Makefile
 	fallback-fb-setup/Makefile
 	flatpak-repos/Makefile
+	journald/Makefile
 	nvidia/Makefile
 	psi-monitor/Makefile
 	record-boot-success/Makefile

--- a/configure.ac
+++ b/configure.ac
@@ -132,6 +132,7 @@ AC_CONFIG_FILES([
 	fallback-fb-setup/Makefile
 	flatpak-repos/Makefile
 	journald/Makefile
+	locale/Makefile
 	nvidia/Makefile
 	psi-monitor/Makefile
 	record-boot-success/Makefile

--- a/journald/Makefile.am
+++ b/journald/Makefile.am
@@ -1,0 +1,2 @@
+journaldconfdir = $(sysconfdir)/systemd/journald.conf.d
+dist_journaldconf_DATA = log.conf

--- a/journald/log.conf
+++ b/journald/log.conf
@@ -1,0 +1,3 @@
+[Journal]
+SystemMaxUse=50M
+SystemMaxFileSize=1M

--- a/journald/log.conf
+++ b/journald/log.conf
@@ -1,3 +1,4 @@
 [Journal]
 SystemMaxUse=50M
 SystemMaxFileSize=1M
+RuntimeMaxUse=4M

--- a/locale/Makefile.am
+++ b/locale/Makefile.am
@@ -1,0 +1,2 @@
+localeconfdir = $(sysconfdir)
+dist_localeconf_DATA = locale.conf

--- a/locale/locale.conf
+++ b/locale/locale.conf
@@ -1,0 +1,1 @@
+LANG=en_US.utf8

--- a/tmpfiles.d/eos-boot-helper.conf
+++ b/tmpfiles.d/eos-boot-helper.conf
@@ -7,3 +7,6 @@ r /var/eos-swap-reclaimed
 # remove stamp file from eos-fix-home-dir-permissions
 # (from 3.1.6 change to default home dir permissions)
 r /var/lib/misc/eos-dir-mode-700
+
+# Store locale info in just 1 place, but add a compat symlink.
+L /etc/default/locale - - - - /etc/locale.conf


### PR DESCRIPTION
* journald: Set the maximum on-disk joural size to 50 MiB
* journald: set RuntimeMaxUse=4M by default
* Create locale config file and compat symlink